### PR TITLE
Remove unused variable in RecordBuilder

### DIFF
--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/InternalRecordBuilderProcessor.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/InternalRecordBuilderProcessor.java
@@ -188,9 +188,11 @@ class InternalRecordBuilderProcessor
                 return new MyRecord(name, r.age());
             }
          */
-        var codeBlockBuilder = CodeBlock.builder()
-                .add("$T r = $L(this);\n", recordClassType.typeName(), metaData.downCastMethodName())
-                .add("return new $T(", recordClassType.typeName());
+        var codeBlockBuilder = CodeBlock.builder();
+        if (recordComponents.size() > 1) {
+            codeBlockBuilder.add("$T r = $L(this);\n", recordClassType.typeName(), metaData.downCastMethodName());
+        }
+        codeBlockBuilder.add("return new $T(", recordClassType.typeName());
         IntStream.range(0, recordComponents.size()).forEach(parameterIndex -> {
             if (parameterIndex > 0) {
                 codeBlockBuilder.add(", ");


### PR DESCRIPTION
Minor issue
There's an unused variable `r` in the builder if the record only have 1 field.
Spotbugs flagged the generated source in my project because of it. This should fix the issue.

Example:
```
@RecordBuilder
public record MyRecord(long id) implements MyRecordBuilder.With {}
```
Generates ->
```
@Generated("io.soabase.recordbuilder.core.RecordBuilder")
public class MyRecordBuilder {
        private long id;

...
....
        /**
         * Return a new instance of {@code MyRecord} with a new value for {@code id}
         */
        @Generated("io.soabase.recordbuilder.core.RecordBuilder")
        default MyRecord withId(long id) {
            var r = (MyRecord)(Object)this;  //<---UNUSED
            return new MyRecord(id);
        }
}
```

I could just exclude the generated sources from spotbugs if you consider this a non bug