### PR TITLE
buildPackageName() can't assume that the immediate enclosing element

### DIFF
--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/Nested.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/Nested.java
@@ -15,14 +15,6 @@
  */
 package io.soabase.recordbuilder.test;
 
-import io.soabase.recordbuilder.core.RecordBuilder;
-import io.soabase.recordbuilder.core.RecordInterface;
-
-@RecordInterface.Include({
-    Thingy.class
-})
-@RecordBuilder.Include({
-    Nested.NestedRecord.class
-})
-public class Builder {
+public class Nested {
+    record NestedRecord(int x, int y){}
 }


### PR DESCRIPTION
buildPackageName() can't assume that the immediate enclosing element is the package. It may be a nested class, etc.