### PR TITLE
Stop relying on toString() to detect package name.

### DIFF
--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/ElementUtils.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/ElementUtils.java
@@ -86,8 +86,9 @@ public class ElementUtils {
                 break;
             }
         }
-        String name = typeElement.getEnclosingElement().toString();
-        return !name.equals("unnamed package") ? name : "";
+        String name = typeElement.getQualifiedName().toString();
+        int index = name.lastIndexOf(".");
+        return (index > -1) ? name.substring(0, index) : "";
     }
 
     public static ClassType getClassType(String packageName, String simpleName, List<? extends TypeParameterElement> typeParameters) {


### PR DESCRIPTION
Fix for #15.

Credit goes to @snjeza for finding this out as part of https://github.com/eclipse/eclipse.jdt.ls/issues/1629