### PR TITLE
Use compileOnly instead of implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ Add the following to your build.gradle file:
 ```
 dependencies {
     annotationProcessor 'io.soabase.record-builder:record-builder-processor:$version-goes-here'
-    implementation 'io.soabase.record-builder:record-builder-core:$version-goes-here'
+    compileOnly 'io.soabase.record-builder:record-builder-core:$version-goes-here'
 }
 
 tasks.withType(JavaCompile) {


### PR DESCRIPTION
Since most users only need the annotations.