### PR TITLE
Use provided/compileOnly instead of implementation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ Add the following to your build.gradle file:
 ```
 dependencies {
     annotationProcessor 'io.soabase.record-builder:record-builder-processor:$version-goes-here'
-    implementation 'io.soabase.record-builder:record-builder-core:$version-goes-here'
+    compileOnly 'io.soabase.record-builder:record-builder-core:$version-goes-here'
 }
 
 tasks.withType(JavaCompile) {

--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ annotation. Use `packagePattern` to change this (see Javadoc for details).
     <groupId>io.soabase.record-builder</groupId>
     <artifactId>record-builder-core</artifactId>
     <version>set-version-here</version>
+    <scope>provided</scope>
 </dependency>
 
 ```

--- a/record-builder-test/pom.xml
+++ b/record-builder-test/pom.xml
@@ -13,6 +13,7 @@
         <dependency>
             <groupId>io.soabase.record-builder</groupId>
             <artifactId>record-builder-core</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Addition to https://github.com/Randgalt/record-builder/pull/17 - add `provided` to Maven usage and doc as well.