### PR TITLE
Add support for Java Platform Module System

### DIFF
--- a/record-builder-core/src/main/java/module-info.java
+++ b/record-builder-core/src/main/java/module-info.java
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2019 Jordan Zimmerman
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module io.soabase.recordbuilder.core {
+    exports io.soabase.recordbuilder.core;
+}


### PR DESCRIPTION
It would be good to add support for JPMS. With this change it will be possible to use record-builder in module-info.java:

```java
module test.module {
    requires static io.soabase.recordbuilder.core;
    requires static java.compiler;
}
```