### PR TITLE
Support copying component annotations to builder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
         <javapoet-version>1.12.1</javapoet-version>
         <junit-jupiter-version>5.5.2</junit-jupiter-version>
         <asm-version>7.2</asm-version>
+        <validation-api-version>2.0.1.Final</validation-api-version>
     </properties>
 
     <name>Record Builder</name>
@@ -112,6 +113,12 @@
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter</artifactId>
                 <version>${junit-jupiter-version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>javax.validation</groupId>
+                <artifactId>validation-api</artifactId>
+                <version>${validation-api-version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/record-builder-core/src/main/java/io/soabase/recordbuilder/core/RecordBuilder.java
+++ b/record-builder-core/src/main/java/io/soabase/recordbuilder/core/RecordBuilder.java
@@ -108,6 +108,14 @@ public @interface RecordBuilder {
          * be prefixed to the builder name if this returns true.
          */
         boolean prefixEnclosingClassNames() default true;
+
+        /**
+         * If true, any annotations (if applicable) on record components are copied
+         * to the builder methods
+         *
+         * @return true/false
+         */
+        boolean inheritComponentAnnotations() default true;
     }
 
     @Retention(RetentionPolicy.SOURCE)

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/RecordClassType.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/RecordClassType.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2019 Jordan Zimmerman
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.soabase.recordbuilder.processor;
+
+import com.squareup.javapoet.TypeName;
+
+import javax.lang.model.element.AnnotationMirror;
+import java.util.List;
+
+public class RecordClassType extends ClassType {
+    private final List<? extends AnnotationMirror> accessorAnnotations;
+    private final List<? extends AnnotationMirror> canonicalConstructorAnnotations;
+
+    public RecordClassType(TypeName typeName, String name, List<? extends AnnotationMirror> accessorAnnotations, List<? extends AnnotationMirror> canonicalConstructorAnnotations) {
+        super(typeName, name);
+        this.accessorAnnotations = accessorAnnotations;
+        this.canonicalConstructorAnnotations = canonicalConstructorAnnotations;
+    }
+
+    public List<? extends AnnotationMirror> getAccessorAnnotations() {
+        return accessorAnnotations;
+    }
+
+    public List<? extends AnnotationMirror> getCanonicalConstructorAnnotations() {
+        return canonicalConstructorAnnotations;
+    }
+}

--- a/record-builder-test/pom.xml
+++ b/record-builder-test/pom.xml
@@ -11,6 +11,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.soabase.record-builder</groupId>
             <artifactId>record-builder-core</artifactId>
             <scope>provided</scope>

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/Annotated.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/Annotated.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2019 Jordan Zimmerman
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.soabase.recordbuilder.test;
+
+import io.soabase.recordbuilder.core.RecordBuilder;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Null;
+
+@RecordBuilder
+public record Annotated(@NotNull @Null String hey, @Min(10) @Max(100) int i, double d) {
+}


### PR DESCRIPTION
Closes #30

- Enabled via new option `inheritComponentAnnotations` (true by default)
- Canonical constructor parameter annotations are copied to RecordBuilder setters and the static builder
- Record component accessor annotations are copied to RecordBuilder getters