### PR TITLE
Set optional fields to empty by default

### DIFF
--- a/java16.sh
+++ b/java16.sh
@@ -16,6 +16,6 @@
 #
 
 
-jenv local 16-ea
+jenv local 16
 javahome
 rm -fr .mvn

--- a/record-builder-core/src/main/java/io/soabase/recordbuilder/core/RecordBuilder.java
+++ b/record-builder-core/src/main/java/io/soabase/recordbuilder/core/RecordBuilder.java
@@ -116,6 +116,12 @@ public @interface RecordBuilder {
          * @return true/false
          */
         boolean inheritComponentAnnotations() default true;
+
+        /**
+         * Set the default value of {@code Optional} record components to
+         * {@code Optional.empty()}
+         */
+        boolean emptyDefaultForOptional() default true;
     }
 
     @Retention(RetentionPolicy.SOURCE)

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/RecordWithOptional.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/RecordWithOptional.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2019 Jordan Zimmerman
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.soabase.recordbuilder.test;
+
+import io.soabase.recordbuilder.core.RecordBuilder;
+
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+
+@RecordBuilder.Options(emptyDefaultForOptional = true)
+@RecordBuilder
+public record RecordWithOptional(Optional<String> value, Optional raw, OptionalInt i, OptionalLong l, OptionalDouble d) {}


### PR DESCRIPTION
Sets `Optional` fields to `empty()` by default. Adds an option
to control this.

Closes #34