### PR TITLE
Add support for NotNull-style annotations

### DIFF
--- a/record-builder-core/src/main/java/io/soabase/recordbuilder/core/RecordBuilder.java
+++ b/record-builder-core/src/main/java/io/soabase/recordbuilder/core/RecordBuilder.java
@@ -15,11 +15,7 @@
  */
 package io.soabase.recordbuilder.core;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Inherited;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
 @Retention(RetentionPolicy.SOURCE)
 @Target(ElementType.TYPE)
@@ -122,6 +118,18 @@ public @interface RecordBuilder {
          * {@code Optional.empty()}
          */
         boolean emptyDefaultForOptional() default true;
+
+        /**
+         * Add not-null checks for record components annotated with any annotation named either "NotNull",
+         * "NoNull", or "NonNull" (see {@link #interpretNotNullsPattern()} for the actual regex matching pattern).
+         */
+        boolean interpretNotNulls() default false;
+
+        /**
+         * If {@link #interpretNotNulls()} is true, this is the regex pattern used to determine if an annotation name
+         * means "not null"
+         */
+        String interpretNotNullsPattern() default "(?i)((notnull)|(nonnull)|(nonull))";
     }
 
     @Retention(RetentionPolicy.SOURCE)

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/RequiredRecord.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/RequiredRecord.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2019 Jordan Zimmerman
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.soabase.recordbuilder.test;
+
+import io.soabase.recordbuilder.core.RecordBuilder;
+
+import javax.validation.constraints.NotNull;
+
+@RecordBuilder.Options(interpretNotNulls = true)
+@RecordBuilder
+public record RequiredRecord(@NotNull String hey, @NotNull int i)
+{
+}


### PR DESCRIPTION
When enabled, annotations matching the configured regex for NotNull
annotations cause `Object.requireNonNull()` to be added for annotated
components.