### PR TITLE
Support validation api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
         <module>record-builder-core</module>
         <module>record-builder-processor</module>
         <module>record-builder-test</module>
+        <module>record-builder-validator</module>
     </modules>
 
     <properties>
@@ -39,6 +40,8 @@
         <junit-jupiter-version>5.5.2</junit-jupiter-version>
         <asm-version>7.2</asm-version>
         <validation-api-version>2.0.1.Final</validation-api-version>
+        <hibernate-validator-version>6.0.16.Final</hibernate-validator-version>
+        <javax-el-version>3.0.1-b09</javax-el-version>
     </properties>
 
     <name>Record Builder</name>
@@ -111,6 +114,12 @@
             </dependency>
 
             <dependency>
+                <groupId>io.soabase.record-builder</groupId>
+                <artifactId>record-builder-validator</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter</artifactId>
                 <version>${junit-jupiter-version}</version>
@@ -120,6 +129,18 @@
                 <groupId>javax.validation</groupId>
                 <artifactId>validation-api</artifactId>
                 <version>${validation-api-version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.hibernate.validator</groupId>
+                <artifactId>hibernate-validator</artifactId>
+                <version>${hibernate-validator-version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.glassfish</groupId>
+                <artifactId>javax.el</artifactId>
+                <version>${javax-el-version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/record-builder-core/src/main/java/io/soabase/recordbuilder/core/RecordBuilder.java
+++ b/record-builder-core/src/main/java/io/soabase/recordbuilder/core/RecordBuilder.java
@@ -130,6 +130,17 @@ public @interface RecordBuilder {
          * means "not null"
          */
         String interpretNotNullsPattern() default "(?i)((notnull)|(nonnull)|(nonull))";
+
+        /**
+         * <p>Pass built records through the Java Validation API if it's available in the classpath.</p>
+         *
+         * <p>IMPORTANT:
+         * if this option is enabled you must include the {@code record-builder-validator} dependency in addition
+         * to {@code record-builder-core}. {@code record-builder-validator} is implemented completely via reflection and
+         * does not require other dependencies. Alternatively, you can define your own class with the package {@code package io.soabase.recordbuilder.validator;}
+         * named {@code RecordBuilderValidator} which has a public static method: {@code public static <T> T validate(T o)}.</p>
+         */
+        boolean useValidationApi() default false;
     }
 
     @Retention(RetentionPolicy.SOURCE)

--- a/record-builder-test/pom.xml
+++ b/record-builder-test/pom.xml
@@ -22,6 +22,23 @@
         </dependency>
 
         <dependency>
+            <groupId>io.soabase.record-builder</groupId>
+            <artifactId>record-builder-validator</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.el</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/RequiredRecord.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/RequiredRecord.java
@@ -19,8 +19,7 @@ import io.soabase.recordbuilder.core.RecordBuilder;
 
 import javax.validation.constraints.NotNull;
 
-@RecordBuilder.Options(interpretNotNulls = true)
+@RecordBuilder.Options(interpretNotNulls = true, useValidationApi = true)
 @RecordBuilder
-public record RequiredRecord(@NotNull String hey, @NotNull int i)
-{
+public record RequiredRecord(@NotNull String hey, @NotNull int i) {
 }

--- a/record-builder-validator/pom.xml
+++ b/record-builder-validator/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>io.soabase.record-builder</groupId>
+        <artifactId>record-builder</artifactId>
+        <version>1.20-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>record-builder-validator</artifactId>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>io.soabase.recordbuilder.validator</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/record-builder-validator/src/main/java/io/soabase/recordbuilder/validator/RecordBuilderValidator.java
+++ b/record-builder-validator/src/main/java/io/soabase/recordbuilder/validator/RecordBuilderValidator.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2019 Jordan Zimmerman
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.soabase.recordbuilder.validator;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.Set;
+
+// complete Java Validation via reflection to avoid dependencies
+public class RecordBuilderValidator {
+    private static final Object validator;
+    private static final Method validationMethod;
+    private static final Constructor<?> constraintViolationExceptionCtor;
+    private static final Class<?>[] emptyGroups = new Class<?>[0];
+
+    private static final boolean PRINT_ERROR_STACKTRACE = Boolean.getBoolean("record_builder_validator_errors");
+
+    static {
+        Object localValidator = null;
+        Method localValidationMethod = null;
+        Constructor<?> localConstraintViolationExceptionCtor = null;
+        try {
+            var validationClass = Class.forName("javax.validation.Validation");
+            var factoryClass = validationClass.getDeclaredMethod("buildDefaultValidatorFactory");
+            var factory = factoryClass.invoke(null);
+            var getValidatorMethod = factory.getClass().getMethod("getValidator");
+            var constraintViolationExceptionClass = Class.forName("javax.validation.ConstraintViolationException");
+            localValidator = getValidatorMethod.invoke(factory);
+            localValidationMethod = localValidator.getClass().getMethod("validate", Object.class, Class[].class);
+            localConstraintViolationExceptionCtor = constraintViolationExceptionClass.getConstructor(Set.class);
+        } catch (Exception e) {
+            if (PRINT_ERROR_STACKTRACE) {
+                e.printStackTrace();
+            }
+        }
+        validator = localValidator;
+        validationMethod = localValidationMethod;
+        constraintViolationExceptionCtor = localConstraintViolationExceptionCtor;
+    }
+
+    public static <T> T validate(T o) {
+        if ((validator != null) && (validationMethod != null)) {
+            try {
+                var violations = validationMethod.invoke(validator, o, emptyGroups);
+                if (!((Collection<?>) violations).isEmpty()) {
+                    throw (RuntimeException) constraintViolationExceptionCtor.newInstance(violations);
+                }
+            } catch (IllegalAccessException | InstantiationException e) {
+                throw new RuntimeException(e);
+            } catch (InvocationTargetException e) {
+                if (e.getCause() != null) {
+                    if (e.getCause() instanceof RuntimeException) {
+                        throw (RuntimeException) e.getCause();
+                    }
+                    throw new RuntimeException(e.getCause());
+                }
+                throw new RuntimeException(e);
+            }
+        }
+        return o;
+    }
+
+    private RecordBuilderValidator() {
+    }
+}


### PR DESCRIPTION
Option to pass created records through the Java Validation API if it's
available in the classpath. IMPORTANT: when enabled, the record-builder-validator
module must also be included. record-builder-validator is written totally
via reflection so if no validation framework is included it's a NOP.
