### PR TITLE
Adds special handling for collection record components

### DIFF
--- a/record-builder-core/src/main/java/io/soabase/recordbuilder/core/RecordBuilder.java
+++ b/record-builder-core/src/main/java/io/soabase/recordbuilder/core/RecordBuilder.java
@@ -136,6 +136,14 @@ public @interface RecordBuilder {
          * named {@code RecordBuilderValidator} which has a public static method: {@code public static <T> T validate(T o)}.</p>
          */
         boolean useValidationApi() default false;
+
+        /**
+         * Adds special handling for record components of type {@link java.util.List}, {@link java.util.Set},
+         * {@link java.util.Map} and {@link java.util.Collection}. When the record is built, any components
+         * of these types are passed through an added shim method that uses the corresponding immutable collection
+         * (e.g. {@code List.copyOf(o)}) or an empty immutable collection if the component is {@code null}.
+         */
+        boolean useImmutableCollections() default false;
     }
 
     @Retention(RetentionPolicy.SOURCE)

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/CollectionBuilderUtils.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/CollectionBuilderUtils.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright 2019 Jordan Zimmerman
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.soabase.recordbuilder.processor;
+
+import com.squareup.javapoet.*;
+
+import javax.lang.model.element.Modifier;
+import java.util.*;
+
+import static io.soabase.recordbuilder.processor.RecordBuilderProcessor.generatedRecordBuilderAnnotation;
+
+class CollectionBuilderUtils {
+    private final boolean enabled;
+    private final String listShimName;
+    private final String mapShimName;
+    private final String setShimName;
+    private final String collectionShimName;
+
+    private boolean needsListShim;
+    private boolean needsMapShim;
+    private boolean needsSetShim;
+    private boolean needsCollectionShim;
+
+    private static final TypeName listType = TypeName.get(List.class);
+    private static final TypeName mapType = TypeName.get(Map.class);
+    private static final TypeName setType = TypeName.get(Set.class);
+    private static final TypeName collectionType = TypeName.get(Collection.class);
+
+    private static final TypeVariableName tType = TypeVariableName.get("T");
+    private static final TypeVariableName kType = TypeVariableName.get("K");
+    private static final TypeVariableName vType = TypeVariableName.get("V");
+    private static final ParameterizedTypeName parameterizedListType = ParameterizedTypeName.get(ClassName.get(List.class), tType);
+    private static final ParameterizedTypeName parameterizedMapType = ParameterizedTypeName.get(ClassName.get(Map.class), kType, vType);
+    private static final ParameterizedTypeName parameterizedSetType = ParameterizedTypeName.get(ClassName.get(Set.class), tType);
+    private static final ParameterizedTypeName parameterizedCollectionType = ParameterizedTypeName.get(ClassName.get(Collection.class), tType);
+
+    CollectionBuilderUtils(List<RecordClassType> recordComponents, boolean enabled) {
+        this.enabled = enabled;
+
+        listShimName = adjustShimName(recordComponents, "__list", 0);
+        mapShimName = adjustShimName(recordComponents, "__map", 0);
+        setShimName = adjustShimName(recordComponents, "__set", 0);
+        collectionShimName = adjustShimName(recordComponents, "__collection", 0);
+    }
+
+    void add(CodeBlock.Builder builder, RecordClassType component) {
+        if (enabled) {
+            if (component.rawTypeName().equals(listType)) {
+                needsListShim = true;
+                builder.add("$L($L)", listShimName, component.name());
+            } else if (component.rawTypeName().equals(mapType)) {
+                needsMapShim = true;
+                builder.add("$L($L)", mapShimName, component.name());
+            } else if (component.rawTypeName().equals(setType)) {
+                needsSetShim = true;
+                builder.add("$L($L)", setShimName, component.name());
+            } else if (component.rawTypeName().equals(collectionType)) {
+                needsCollectionShim = true;
+                builder.add("$L($L)", collectionShimName, component.name());
+            } else {
+                builder.add("$L", component.name());
+            }
+        } else {
+            builder.add("$L", component.name());
+        }
+    }
+
+    void addShims(TypeSpec.Builder builder) {
+        if (!enabled) {
+            return;
+        }
+
+        if (needsListShim) {
+            builder.addMethod(buildMethod(listShimName, listType, parameterizedListType, tType));
+        }
+        if (needsSetShim) {
+            builder.addMethod(buildMethod(setShimName, setType, parameterizedSetType, tType));
+        }
+        if (needsMapShim) {
+            builder.addMethod(buildMethod(mapShimName, mapType, parameterizedMapType, kType, vType));
+        }
+        if (needsCollectionShim) {
+            builder.addMethod(buildCollectionsMethod());
+        }
+    }
+
+    private String adjustShimName(List<RecordClassType> recordComponents, String baseName, int index)
+    {
+        var name = (index == 0) ? baseName : (baseName + index);
+        if (recordComponents.stream().anyMatch(component -> component.name().equals(name))) {
+            return adjustShimName(recordComponents, baseName, index + 1);
+        }
+        return name;
+    }
+
+    private MethodSpec buildMethod(String name, TypeName mainType, ParameterizedTypeName parameterizedType, TypeVariableName... typeVariables) {
+        var code = CodeBlock.of("return (o != null) ? $T.copyOf(o) : $T.of()", mainType, mainType);
+        return MethodSpec.methodBuilder(name)
+                .addAnnotation(generatedRecordBuilderAnnotation)
+                .addModifiers(Modifier.PRIVATE, Modifier.STATIC)
+                .addTypeVariables(Arrays.asList(typeVariables))
+                .returns(parameterizedType)
+                .addParameter(parameterizedType, "o")
+                .addStatement(code)
+                .build();
+    }
+
+    private MethodSpec buildCollectionsMethod() {
+        var code = CodeBlock.builder()
+                .add("if (o instanceof Set) {\n")
+                .indent()
+                .addStatement("return (o != null) ? $T.copyOf(o) : $T.of()", setType, setType)
+                .unindent()
+                .addStatement("}")
+                .addStatement("return (o != null) ? $T.copyOf(o) : $T.of()", listType, listType)
+                .build();
+        return MethodSpec.methodBuilder(collectionShimName)
+                .addAnnotation(generatedRecordBuilderAnnotation)
+                .addModifiers(Modifier.PRIVATE, Modifier.STATIC)
+                .addTypeVariable(tType)
+                .returns(parameterizedCollectionType)
+                .addParameter(parameterizedCollectionType, "o")
+                .addCode(code)
+                .build();
+    }
+}

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/ElementUtils.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/ElementUtils.java
@@ -108,8 +108,10 @@ public class ElementUtils {
         return new ClassType(ParameterizedTypeName.get(builderClassName, typeNames), builderClassName.simpleName());
     }
 
-    public static RecordClassType getRecordClassType(RecordComponentElement recordComponent, List<? extends AnnotationMirror> accessorAnnotations, List<? extends AnnotationMirror> canonicalConstructorAnnotations) {
-        return new RecordClassType(TypeName.get(recordComponent.asType()), recordComponent.getSimpleName().toString(), accessorAnnotations, canonicalConstructorAnnotations);
+    public static RecordClassType getRecordClassType(ProcessingEnvironment processingEnv, RecordComponentElement recordComponent, List<? extends AnnotationMirror> accessorAnnotations, List<? extends AnnotationMirror> canonicalConstructorAnnotations) {
+        var typeName = TypeName.get(recordComponent.asType());
+        var rawTypeName = TypeName.get(processingEnv.getTypeUtils().erasure(recordComponent.asType()));
+        return new RecordClassType(typeName, rawTypeName, recordComponent.getSimpleName().toString(), accessorAnnotations, canonicalConstructorAnnotations);
     }
 
     public static String getWithMethodName(ClassType component, String prefix) {

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/RecordBuilderProcessor.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/RecordBuilderProcessor.java
@@ -181,7 +181,7 @@ public class RecordBuilderProcessor
             processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, "RecordBuilder only valid for records.", record);
             return;
         }
-        var internalProcessor = new InternalRecordBuilderProcessor(record, metaData, packageName);
+        var internalProcessor = new InternalRecordBuilderProcessor(processingEnv, record, metaData, packageName);
         writeRecordBuilderJavaFile(record, internalProcessor.packageName(), internalProcessor.builderClassType(), internalProcessor.builderType(), metaData);
     }
 

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/RecordClassType.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/RecordClassType.java
@@ -21,13 +21,19 @@ import javax.lang.model.element.AnnotationMirror;
 import java.util.List;
 
 public class RecordClassType extends ClassType {
+    private final TypeName rawTypeName;
     private final List<? extends AnnotationMirror> accessorAnnotations;
     private final List<? extends AnnotationMirror> canonicalConstructorAnnotations;
 
-    public RecordClassType(TypeName typeName, String name, List<? extends AnnotationMirror> accessorAnnotations, List<? extends AnnotationMirror> canonicalConstructorAnnotations) {
+    public RecordClassType(TypeName typeName, TypeName rawTypeName, String name, List<? extends AnnotationMirror> accessorAnnotations, List<? extends AnnotationMirror> canonicalConstructorAnnotations) {
         super(typeName, name);
+        this.rawTypeName = rawTypeName;
         this.accessorAnnotations = accessorAnnotations;
         this.canonicalConstructorAnnotations = canonicalConstructorAnnotations;
+    }
+
+    public TypeName rawTypeName() {
+        return rawTypeName;
     }
 
     public List<? extends AnnotationMirror> getAccessorAnnotations() {

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/CollectionRecord.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/CollectionRecord.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2019 Jordan Zimmerman
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.soabase.recordbuilder.test;
+
+import io.soabase.recordbuilder.core.RecordBuilder;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@RecordBuilder
+@RecordBuilder.Options(useImmutableCollections = true)
+public record CollectionRecord<T, X extends Point>(List<T> l, Set<T> s, Map<T, X> m, Collection<X> c) implements CollectionRecordBuilder.With<T, X> {
+}

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/CollectionRecordConflicts.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/CollectionRecordConflicts.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2019 Jordan Zimmerman
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.soabase.recordbuilder.test;
+
+import io.soabase.recordbuilder.core.RecordBuilder;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@RecordBuilder
+@RecordBuilder.Options(useImmutableCollections = true)
+public record CollectionRecordConflicts(List<String> __list, Set<String> __set, Map<String, String> __map, Collection<String> __collection) implements CollectionRecordConflictsBuilder.With {
+}

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/MutableCollectionRecord.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/MutableCollectionRecord.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2019 Jordan Zimmerman
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.soabase.recordbuilder.test;
+
+import io.soabase.recordbuilder.core.RecordBuilder;
+
+import java.util.List;
+
+@RecordBuilder
+public record MutableCollectionRecord(List<String> l) implements MutableCollectionRecordBuilder.With {
+}

--- a/record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestCollections.java
+++ b/record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestCollections.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright 2019 Jordan Zimmerman
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.soabase.recordbuilder.test;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+import static io.soabase.recordbuilder.test.foo.PointBuilder.Point;
+import static org.junit.jupiter.api.Assertions.*;
+
+class TestCollections {
+    @Test
+    void testCollectionRecordDefaultValues() {
+        var defaultValues = CollectionRecordBuilder.builder().build();
+        assertNotNull(defaultValues.l());
+        assertNotNull(defaultValues.s());
+        assertNotNull(defaultValues.m());
+        assertNotNull(defaultValues.c());
+    }
+
+    @Test
+    void testCollectionRecordImmutable() {
+        var list = new ArrayList<String>();
+        list.add("one");
+        var set = new HashSet<String>();
+        set.add("one");
+        var map = new HashMap<String, Point>();
+        map.put("one", Point(10, 20));
+        var collectionAsSet = new HashSet<Point>();
+        collectionAsSet.add(Point(30, 40));
+        var r = CollectionRecordBuilder.<String, Point>builder()
+                .l(list)
+                .s(set)
+                .m(map)
+                .c(collectionAsSet)
+                .build();
+
+        assertValues(r, list, set, map, collectionAsSet);
+        assertValueChanges(r, list, set, map, collectionAsSet);
+        assertImmutable(r);
+
+        var collectionAsList = new ArrayList<Point>();
+        var x = CollectionRecordBuilder.<String, Point>builder()
+                .l(list)
+                .s(set)
+                .m(map)
+                .c(collectionAsList)
+                .build();
+        assertTrue(x.c() instanceof List);
+    }
+
+    @Test
+    void testCollectionRecordImmutableWithers() {
+        var r = CollectionRecordBuilder.<String, Point>builder().build();
+
+        var list = new ArrayList<String>();
+        list.add("one");
+        var set = new HashSet<String>();
+        set.add("one");
+        var map = new HashMap<String, Point>();
+        map.put("one", Point(10, 20));
+        var collectionAsSet = new HashSet<Point>();
+        collectionAsSet.add(Point(30, 40));
+        var x = r.withL(list).withS(set).withM(map).withC(collectionAsSet);
+
+        assertValues(x, list, set, map, collectionAsSet);
+        assertValueChanges(x, list, set, map, collectionAsSet);
+        assertImmutable(x);
+    }
+
+    @Test
+    public void testMutableCollectionRecord() {
+        var r = MutableCollectionRecordBuilder.builder().build();
+        assertNull(r.l());
+
+        var list = new ArrayList<String>();
+        list.add("one");
+        r = MutableCollectionRecordBuilder.builder().l(list).build();
+
+        assertEquals(r.l(), list);
+        list.add("two");
+        assertEquals(r.l(), list);
+    }
+
+    private void assertImmutable(CollectionRecord<String, Point> r) {
+        assertThrows(UnsupportedOperationException.class, () -> r.l().add("hey"));
+        assertThrows(UnsupportedOperationException.class, () -> r.s().add("hey"));
+        assertThrows(UnsupportedOperationException.class, () -> r.m().put("hey", Point(1, 2)));
+        assertThrows(UnsupportedOperationException.class, () -> r.c().add(Point(1, 2)));
+    }
+
+    private void assertValueChanges(CollectionRecord<String, Point> r, ArrayList<String> list, HashSet<String> set, HashMap<String, Point> map, HashSet<Point> collectionAsSet) {
+        list.add("two");
+        set.add("two");
+        map.put("two", Point(50, 60));
+        collectionAsSet.add(Point(70, 80));
+
+        assertNotEquals(r.l(), list);
+        assertNotEquals(r.s(), set);
+        assertNotEquals(r.m(), map);
+        assertNotEquals(r.c(), collectionAsSet);
+    }
+
+    private void assertValues(CollectionRecord<String, Point> r, ArrayList<String> list, HashSet<String> set, HashMap<String, Point> map, HashSet<Point> collectionAsSet) {
+        assertEquals(r.l(), list);
+        assertEquals(r.s(), set);
+        assertEquals(r.m(), map);
+        assertEquals(r.c(), collectionAsSet);
+        assertTrue(r.c() instanceof Set);
+    }
+}


### PR DESCRIPTION
Adds special handling for record components of type `java.util.List`, `java.util.Set`, `java.util.Map` and `java.util.Collection`. When the record is built, any components of these types are passed through an added shim method that uses the corresponding immutable collection (e.g. `List.copyOf(o)`) or an empty immutable collection if the component is null.

This is what the generated builder looks like: [CollectionRecordBuilder.java](https://gist.github.com/Randgalt/01acd70fedb2c474b5af6d8d0fc452a8)

Closes #56
Closes #58