### PR TITLE
Match record visibility

### DIFF
--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/visibility/PackagePrivateRecord.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/visibility/PackagePrivateRecord.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2019 Jordan Zimmerman
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.soabase.recordbuilder.test.visibility;
+
+import io.soabase.recordbuilder.core.RecordBuilder;
+
+@RecordBuilder
+record PackagePrivateRecord(int i) {
+}

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/visibility/Wrapper.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/visibility/Wrapper.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2019 Jordan Zimmerman
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.soabase.recordbuilder.test.visibility;
+
+import io.soabase.recordbuilder.core.RecordBuilder;
+
+class Wrapper {
+    @RecordBuilder
+    protected record ProtectedRecord(int i) {
+    }
+
+    @RecordBuilder
+    record PackagePrivateRecord(int i) {
+    }
+}

--- a/record-builder-test/src/test/java/io/soabase/recordbuilder/test/visibility/TestVisibility.java
+++ b/record-builder-test/src/test/java/io/soabase/recordbuilder/test/visibility/TestVisibility.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2019 Jordan Zimmerman
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.soabase.recordbuilder.test.visibility;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Modifier;
+
+class TestVisibility {
+    @Test
+    void testMatches() {
+        Assertions.assertFalse(Modifier.isPublic(PackagePrivateRecordBuilder.class.getModifiers()));
+        Assertions.assertFalse(Modifier.isPrivate(PackagePrivateRecordBuilder.class.getModifiers()));
+        Assertions.assertFalse(Modifier.isProtected(PackagePrivateRecordBuilder.class.getModifiers()));
+
+        Assertions.assertTrue(Modifier.isPublic(WrapperProtectedRecordBuilder.class.getModifiers()));
+    }
+}


### PR DESCRIPTION
If the builder is in the same package as the record and the record
is package-private, make the builder package-private too.

Closes #52