### PR TITLE
Support single item collection builders

### DIFF
--- a/record-builder-core/src/main/java/io/soabase/recordbuilder/core/RecordBuilder.java
+++ b/record-builder-core/src/main/java/io/soabase/recordbuilder/core/RecordBuilder.java
@@ -164,6 +164,19 @@ public @interface RecordBuilder {
          * (e.g. {@code List.copyOf(o)}) or an empty immutable collection if the component is {@code null}.
          */
         boolean useImmutableCollections() default false;
+
+        /**
+         * When enabled, collection types ({@code List}, {@code Set} and {@code Map}) are handled specially.
+         * The setters for these types now create an internal collection and items are added to that
+         * collection. Additionally, "adder" methods prefixed with {@link #singleItemBuilderPrefix()} are created
+         * to add single items to these collections.
+         */
+        boolean addSingleItemCollectionBuilders() default false;
+
+        /**
+         * The prefix for adder methods when {@link #addSingleItemCollectionBuilders()} is enabled
+         */
+        String singleItemBuilderPrefix() default "add";
     }
 
     @Retention(RetentionPolicy.CLASS)

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/CollectionBuilderUtils.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/CollectionBuilderUtils.java
@@ -16,6 +16,7 @@
 package io.soabase.recordbuilder.processor;
 
 import com.squareup.javapoet.*;
+import io.soabase.recordbuilder.core.RecordBuilder;
 
 import javax.lang.model.element.Modifier;
 import java.util.*;
@@ -23,7 +24,8 @@ import java.util.*;
 import static io.soabase.recordbuilder.processor.RecordBuilderProcessor.generatedRecordBuilderAnnotation;
 
 class CollectionBuilderUtils {
-    private final boolean enabled;
+    private final boolean useImmutableCollections;
+    private final boolean addSingleItemCollectionBuilders;
     private final String listShimName;
     private final String mapShimName;
     private final String setShimName;
@@ -47,8 +49,9 @@ class CollectionBuilderUtils {
     private static final ParameterizedTypeName parameterizedSetType = ParameterizedTypeName.get(ClassName.get(Set.class), tType);
     private static final ParameterizedTypeName parameterizedCollectionType = ParameterizedTypeName.get(ClassName.get(Collection.class), tType);
 
-    CollectionBuilderUtils(List<RecordClassType> recordComponents, boolean enabled) {
-        this.enabled = enabled;
+    CollectionBuilderUtils(List<RecordClassType> recordComponents, RecordBuilder.Options metaData) {
+        useImmutableCollections = metaData.useImmutableCollections();
+        addSingleItemCollectionBuilders = metaData.addSingleItemCollectionBuilders();
 
         listShimName = adjustShimName(recordComponents, "__list", 0);
         mapShimName = adjustShimName(recordComponents, "__map", 0);
@@ -56,15 +59,77 @@ class CollectionBuilderUtils {
         collectionShimName = adjustShimName(recordComponents, "__collection", 0);
     }
 
+    enum SingleItemsMetaDataMode {
+        STANDARD,
+        STANDARD_FOR_SETTER,
+        EXCLUDE_WILDCARD_TYPES
+    }
+
+    record SingleItemsMetaData(Class<?> singleItemCollectionClass, List<TypeName> typeArguments, TypeName wildType) {}
+
+    Optional<SingleItemsMetaData> singleItemsMetaData(RecordClassType component, SingleItemsMetaDataMode mode) {
+        if (addSingleItemCollectionBuilders && (component.typeName() instanceof ParameterizedTypeName parameterizedTypeName)) {
+            Class<?> collectionClass = null;
+            ClassName wildcardClass = null;
+            int typeArgumentQty = 0;
+            if (isList(component)) {
+                collectionClass = ArrayList.class;
+                wildcardClass = ClassName.get(Collection.class);
+                typeArgumentQty = 1;
+            } else if (isSet(component)) {
+                collectionClass = HashSet.class;
+                wildcardClass = ClassName.get(Collection.class);
+                typeArgumentQty = 1;
+            } else if (isMap(component)) {
+                collectionClass = HashMap.class;
+                wildcardClass = (ClassName) component.rawTypeName();
+                typeArgumentQty = 2;
+            }
+            var hasWildcardTypeArguments = hasWildcardTypeArguments(parameterizedTypeName, typeArgumentQty);
+            if (collectionClass != null) {
+                return switch (mode) {
+                    case STANDARD -> singleItemsMetaDataWithWildType(parameterizedTypeName, collectionClass, wildcardClass, typeArgumentQty);
+
+                    case STANDARD_FOR_SETTER -> {
+                        if (hasWildcardTypeArguments) {
+                            yield Optional.of(new SingleItemsMetaData(collectionClass, parameterizedTypeName.typeArguments, component.typeName()));
+                        }
+                        yield singleItemsMetaDataWithWildType(parameterizedTypeName, collectionClass, wildcardClass, typeArgumentQty);
+                    }
+
+                    case EXCLUDE_WILDCARD_TYPES -> {
+                        if (hasWildcardTypeArguments) {
+                            yield Optional.empty();
+                        }
+                        yield singleItemsMetaDataWithWildType(parameterizedTypeName, collectionClass, wildcardClass, typeArgumentQty);
+                    }
+                };
+            }
+        }
+        return Optional.empty();
+    }
+
+    boolean isList(RecordClassType component) {
+        return component.rawTypeName().equals(listType);
+    }
+
+    boolean isMap(RecordClassType component) {
+        return component.rawTypeName().equals(mapType);
+    }
+
+    boolean isSet(RecordClassType component) {
+        return component.rawTypeName().equals(setType);
+    }
+
     void add(CodeBlock.Builder builder, RecordClassType component) {
-        if (enabled) {
-            if (component.rawTypeName().equals(listType)) {
+        if (useImmutableCollections) {
+            if (isList(component)) {
                 needsListShim = true;
                 builder.add("$L($L)", listShimName, component.name());
-            } else if (component.rawTypeName().equals(mapType)) {
+            } else if (isMap(component)) {
                 needsMapShim = true;
                 builder.add("$L($L)", mapShimName, component.name());
-            } else if (component.rawTypeName().equals(setType)) {
+            } else if (isSet(component)) {
                 needsSetShim = true;
                 builder.add("$L($L)", setShimName, component.name());
             } else if (component.rawTypeName().equals(collectionType)) {
@@ -79,7 +144,7 @@ class CollectionBuilderUtils {
     }
 
     void addShims(TypeSpec.Builder builder) {
-        if (!enabled) {
+        if (!useImmutableCollections) {
             return;
         }
 
@@ -97,8 +162,28 @@ class CollectionBuilderUtils {
         }
     }
 
-    private String adjustShimName(List<RecordClassType> recordComponents, String baseName, int index)
-    {
+    private Optional<SingleItemsMetaData> singleItemsMetaDataWithWildType(ParameterizedTypeName parameterizedTypeName, Class<?> collectionClass, ClassName wildcardClass, int typeArgumentQty) {
+        TypeName wildType;
+        if (typeArgumentQty == 1) {
+            wildType = ParameterizedTypeName.get(wildcardClass, WildcardTypeName.subtypeOf(parameterizedTypeName.typeArguments.get(0)));
+        } else { // if (typeArgumentQty == 2)
+            wildType = ParameterizedTypeName.get(wildcardClass, WildcardTypeName.subtypeOf(parameterizedTypeName.typeArguments.get(0)), WildcardTypeName.subtypeOf(parameterizedTypeName.typeArguments.get(1)));
+        }
+        return Optional.of(new SingleItemsMetaData(collectionClass, parameterizedTypeName.typeArguments, wildType));
+    }
+
+    private boolean hasWildcardTypeArguments(ParameterizedTypeName parameterizedTypeName, int argumentCount) {
+        for (int i = 0; i < argumentCount; ++i) {
+            if (parameterizedTypeName.typeArguments.size() > i) {
+                if (parameterizedTypeName.typeArguments.get(i) instanceof WildcardTypeName) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private String adjustShimName(List<RecordClassType> recordComponents, String baseName, int index) {
         var name = (index == 0) ? baseName : (baseName + index);
         if (recordComponents.stream().anyMatch(component -> component.name().equals(name))) {
             return adjustShimName(recordComponents, baseName, index + 1);

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/SingleItems.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/SingleItems.java
@@ -13,21 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.soabase.recordbuilder.core;
+package io.soabase.recordbuilder.test;
 
-import java.lang.annotation.*;
+import io.soabase.recordbuilder.core.RecordBuilder;
 
-@RecordBuilder.Template(options = @RecordBuilder.Options(
-        interpretNotNulls = true,
-        useImmutableCollections = true,
-        addSingleItemCollectionBuilders = true
-))
-@Retention(RetentionPolicy.SOURCE)
-@Target(ElementType.TYPE)
-@Inherited
-/**
- * An alternate form of {@code @RecordBuilder} that has most
- * optional features turned on
- */
-public @interface RecordBuilderFull {
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@RecordBuilder
+@RecordBuilder.Options(
+        addSingleItemCollectionBuilders = true,
+        singleItemBuilderPrefix = "add1",
+        useImmutableCollections = true
+)
+public record SingleItems<T>(List<String> strings, Set<List<T>> sets, Map<Instant, T> map, Collection<T> collection) implements SingleItemsBuilder.With<T> {
 }

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/WildcardSingleItems.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/WildcardSingleItems.java
@@ -13,21 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.soabase.recordbuilder.core;
+package io.soabase.recordbuilder.test;
 
-import java.lang.annotation.*;
+import io.soabase.recordbuilder.core.RecordBuilder;
 
-@RecordBuilder.Template(options = @RecordBuilder.Options(
-        interpretNotNulls = true,
-        useImmutableCollections = true,
-        addSingleItemCollectionBuilders = true
-))
-@Retention(RetentionPolicy.SOURCE)
-@Target(ElementType.TYPE)
-@Inherited
-/**
- * An alternate form of {@code @RecordBuilder} that has most
- * optional features turned on
- */
-public @interface RecordBuilderFull {
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@RecordBuilder
+@RecordBuilder.Options(
+        addSingleItemCollectionBuilders = true,
+        useImmutableCollections = true
+)
+public record WildcardSingleItems<T>(List<? extends String> strings, Set<? extends List<? extends T>> sets, Map<? extends Instant, ? extends T> map, Collection<? extends T> collection) implements WildcardSingleItemsBuilder.With<T> {
 }

--- a/record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestSingleItems.java
+++ b/record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestSingleItems.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2019 Jordan Zimmerman
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.soabase.recordbuilder.test;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class TestSingleItems {
+    @Test
+    public void testInternalCollections()
+    {
+        var now = Instant.now();
+        var item = SingleItemsBuilder.<String>builder()
+                .add1Map(now, "now")
+                .add1Map(Instant.MIN, "before")
+                .add1Sets(Arrays.asList("1", "2"))
+                .add1Sets(List.of("3"))
+                .add1Strings("a")
+                .add1Strings("b")
+                .add1Strings("c")
+                .build();
+        Assertions.assertEquals(item.map(), Map.of(now, "now", Instant.MIN, "before"));
+        Assertions.assertEquals(item.sets(), Set.of(List.of("1", "2"), List.of("3")));
+        Assertions.assertEquals(item.strings(), List.of("a", "b", "c"));
+
+        var copy = item.with()
+                .add1Strings("new")
+                .add1Map(Instant.MAX, "after")
+                .add1Sets(List.of("10", "20", "30"))
+                .build();
+        Assertions.assertNotEquals(item, copy);
+        Assertions.assertEquals(copy.map(), Map.of(now, "now", Instant.MIN, "before", Instant.MAX, "after"));
+        Assertions.assertEquals(copy.sets(), Set.of(List.of("1", "2"), List.of("3"), List.of("10", "20", "30")));
+        Assertions.assertEquals(copy.strings(), List.of("a", "b", "c", "new"));
+
+        var stringsToAdd = Arrays.asList("x", "y", "z");
+        var listToAdd = Arrays.asList(List.of("aa", "bb"), List.of("cc"));
+        var mapToAdd = Map.of(now.plusMillis(1), "now+1", now.plusMillis(2), "now+2");
+        var streamed = SingleItemsBuilder.builder(item)
+                .add1Strings(stringsToAdd.stream())
+                .add1Sets(listToAdd.stream())
+                .add1Map(mapToAdd.entrySet().stream())
+                .build();
+        Assertions.assertEquals(streamed.map(), Map.of(now, "now", Instant.MIN, "before", now.plusMillis(1), "now+1", now.plusMillis(2), "now+2"));
+        Assertions.assertEquals(streamed.sets(), Set.of(List.of("1", "2"), List.of("3"), List.of("aa", "bb"), List.of("cc")));
+        Assertions.assertEquals(streamed.strings(), Arrays.asList("a", "b", "c", "x", "y", "z"));
+
+        var nulls = SingleItemsBuilder.builder(item)
+                .strings(null)
+                .sets(null)
+                .map(null)
+                .build();
+        Assertions.assertEquals(nulls.map(), Map.of());
+        Assertions.assertEquals(nulls.sets(), Set.of());
+        Assertions.assertEquals(nulls.strings(), List.of());
+    }
+}


### PR DESCRIPTION
When `addSingleItemCollectionBuilders()` is enabled in options, collection types (`List`, `Set` and `Map`)
are handled specially. The setters for these types now create an internal collection and
items are added to that collection. Additionally, "adder" methods prefixed with
`singleItemBuilderPrefix()` are created to add single items to these collections.

The generated builder looks like this: https://gist.github.com/Randgalt/8aa487a847ea2acdd76d702f7cf17d6a

cc @tmichel

Closes #73