### PR TITLE
Add configurable method name prefixes to builders

### DIFF
--- a/record-builder-core/src/main/java/io/soabase/recordbuilder/core/RecordBuilder.java
+++ b/record-builder-core/src/main/java/io/soabase/recordbuilder/core/RecordBuilder.java
@@ -187,6 +187,38 @@ public @interface RecordBuilder {
          * When enabled, adds functional methods to the nested "With" class (such as {@code map()} and {@code accept()}).
          */
         boolean addFunctionalMethodsToWith() default false;
+
+        /**
+         * If set, all builder setter methods will be prefixed with this string. Camel-casing will
+         * still be enforced, so if this option is set to "set" a field named "myField" will get
+         * a corresponding setter named "setMyField".
+         */
+        String setterPrefix() default "";
+
+        /**
+         * If set, all builder getter methods will be prefixed with this string. Camel-casing will
+         * still be enforced, so if this option is set to "get", a field named "myField" will get
+         * a corresponding getter named "getMyField".
+         */
+        String getterPrefix() default "";
+
+        /**
+         * If set, all boolean builder getter methods will be prefixed with this string.
+         * Camel-casing will still be enforced, so if this option is set to "is", a field named
+         * "myField" will get a corresponding getter named "isMyField".
+         */
+        String booleanPrefix() default "";
+
+        /**
+         * If set, the Builder will contain an internal interface with this name. This interface
+         * contains getters for all the fields in the Record prefixed with the value supplied in
+         * {@link this.getterPrefix} and {@link this.booleanPrefix}. This interface can be
+         * implemented by the original Record to have proper bean-style prefixed getters.
+         *
+         * Please note that unless either of the aforementioned prefixes are set,
+         * this option does nothing.
+         */
+        String beanClassName() default "";
     }
 
     @Retention(RetentionPolicy.CLASS)

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/CustomMethodNames.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/CustomMethodNames.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2019 Jordan Zimmerman
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.soabase.recordbuilder.test;
+
+import java.util.List;
+import io.soabase.recordbuilder.core.RecordBuilder;
+import io.soabase.recordbuilder.test.CustomMethodNamesBuilder.Bean;
+
+@RecordBuilder
+@RecordBuilder.Options(
+    setterPrefix = "set", getterPrefix = "get", booleanPrefix = "is", beanClassName = "Bean")
+public record CustomMethodNames(
+    int theValue,
+    List<Integer> theList,
+    boolean theBoolean) implements Bean {
+}

--- a/record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestCustomMethodNames.java
+++ b/record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestCustomMethodNames.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2019 Jordan Zimmerman
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.soabase.recordbuilder.test;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestCustomMethodNames {
+
+  @Test
+  public void builderGetsCustomSetterAndGetterNames() {
+    var obj = CustomMethodNamesBuilder.builder()
+        .setTheValue(1)
+        .setTheList(List.of(2))
+        .setTheBoolean(true);
+    assertEquals(1, obj.getTheValue());
+    assertEquals(List.of(2), obj.getTheList());
+    assertTrue(obj.isTheBoolean());
+    assertEquals(new CustomMethodNames(1, List.of(2), true), obj.build());
+  }
+
+  @Test
+  public void withBuilderGetsCustomSetterAndGetterNames() {
+    var obj = CustomMethodNamesBuilder.from(CustomMethodNamesBuilder.builder()
+            .setTheValue(1)
+            .setTheList(List.of(2))
+            .setTheBoolean(true)
+            .build());
+    assertEquals(1, obj.getTheValue());
+    assertEquals(List.of(2), obj.getTheList());
+    assertTrue(obj.isTheBoolean());
+  }
+
+  @Test
+  public void recordHasPrefixedGetters() {
+    var obj = new CustomMethodNames(1, List.of(2), true);
+    assertEquals(1, obj.getTheValue());
+    assertEquals(List.of(2), obj.getTheList());
+    assertTrue(obj.isTheBoolean());
+  }
+}


### PR DESCRIPTION
Sometimes I feel old and conservative and want to do things the old way.

Just kidding;
We have a giant codebase built on top of Immutables.org. It makes builders with setter methods. To make our migration to records as painless as possible, it is nice to migrate without having to rename the usage of Immutables builders for thousands of classes.

Also, get* set* and is* have been idiomatic Java since "forever". Some people might prefer these prefixes, even if they *do* make the methods three characters longer