### PR TITLE
Fix NPE for uninitialized non-null collection

### DIFF
--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/InternalRecordBuilderProcessor.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/InternalRecordBuilderProcessor.java
@@ -521,6 +521,14 @@ class InternalRecordBuilderProcessor {
         */
 
         var codeBuilder = CodeBlock.builder();
+
+        IntStream.range(0, recordComponents.size()).forEach(index -> {
+            var recordComponent = recordComponents.get(index);
+            codeBuilder.add("$[$L = ", recordComponent.name());
+            collectionBuilderUtils.add(codeBuilder, recordComponents.get(index));
+            codeBuilder.add(";\n$]");
+        });
+
         addNullCheckCodeBlock(codeBuilder);
         codeBuilder.add("$[return ");
         if (metaData.useValidationApi()) {
@@ -531,7 +539,7 @@ class InternalRecordBuilderProcessor {
             if (index > 0) {
                 codeBuilder.add(", ");
             }
-            collectionBuilderUtils.add(codeBuilder, recordComponents.get(index));
+            codeBuilder.add("$L", recordComponents.get(index).name());
         });
         codeBuilder.add(")");
         if (metaData.useValidationApi()) {

--- a/record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestRecordBuilderFull.java
+++ b/record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestRecordBuilderFull.java
@@ -20,11 +20,15 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 class TestRecordBuilderFull {
     @Test
     void testNonNull() {
-        Assertions.assertThrows(NullPointerException.class, () -> FullRecordBuilder.builder().build());
+        var record = FullRecordBuilder.builder().build();
+        Assertions.assertEquals(List.of(), record.numbers());
+        Assertions.assertEquals(Map.of(), record.fullRecords());
     }
 
     @Test


### PR DESCRIPTION
Closes #91

This is a tentative patch for #91. I'm not familiar with record-builder code base, so I prefer to share an early draft and get feedback before trying to polish it. 

The idea is to move  collection shims invocation before null checks. 

Before:

```
    public Removeme.R build() {
        Objects.requireNonNull(l, "l is required");
        return new Removeme.R(__list(l));
    }
```

After:
```
    public Removeme.R build() {
        l = __list(l);
        Objects.requireNonNull(l, "l is required");
        return new Removeme.R(l);
    }
```

Shortcomings:
 * Break backward compatibility. I find that current behavior is a bug, but others might disagree and rely on current semantic. See updated test for impact.
 * Current implementation will emit many useless `x = x;` assignments. If that's a problem we can filter non collection components.

