### PR TITLE
Add flag to add concrete setters for optionals

### DIFF
--- a/record-builder-core/src/main/java/io/soabase/recordbuilder/core/RecordBuilder.java
+++ b/record-builder-core/src/main/java/io/soabase/recordbuilder/core/RecordBuilder.java
@@ -145,6 +145,11 @@ public @interface RecordBuilder {
         boolean emptyDefaultForOptional() default true;
 
         /**
+         * Add non-optional setter methods for optional record components.
+         */
+        boolean addConcreteSettersForOptional() default false;
+
+        /**
          * Add not-null checks for record components annotated with any annotation named either "NotNull",
          * "NoNull", or "NonNull" (see {@link #interpretNotNullsPattern()} for the actual regex matching pattern).
          */

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/OptionalType.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/OptionalType.java
@@ -39,10 +39,9 @@ public record OptionalType(TypeName typeName, TypeName valueType) {
 
     static Optional<OptionalType> fromClassType(final ClassType component) {
         if (isOptional(component)) {
-            if (!(component.typeName() instanceof ParameterizedTypeName)) {
+            if (!(component.typeName() instanceof ParameterizedTypeName parameterizedType)) {
                 return Optional.of(new OptionalType(optionalType, TypeName.get(Object.class)));
             }
-            var parameterizedType = (ParameterizedTypeName) component.typeName();
             final TypeName containingType = parameterizedType.typeArguments.isEmpty()
                     ? TypeName.get(Object.class)
                     : parameterizedType.typeArguments.get(0);

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/OptionalType.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/OptionalType.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2019 Jordan Zimmerman
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.soabase.recordbuilder.processor;
+
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+import com.squareup.javapoet.ParameterizedTypeName;
+import com.squareup.javapoet.TypeName;
+
+public record OptionalType(TypeName typeName, TypeName valueType) {
+
+    private static final TypeName optionalType = TypeName.get(Optional.class);
+    private static final TypeName optionalIntType = TypeName.get(OptionalInt.class);
+    private static final TypeName optionalLongType = TypeName.get(OptionalLong.class);
+    private static final TypeName optionalDoubleType = TypeName.get(OptionalDouble.class);
+
+    private static boolean isOptional(ClassType component) {
+        if (component.typeName().equals(optionalType)) {
+            return true;
+        }
+        return (component.typeName() instanceof ParameterizedTypeName parameterizedTypeName)
+                && parameterizedTypeName.rawType.equals(optionalType);
+    }
+
+    static Optional<OptionalType> fromClassType(final ClassType component) {
+        if (isOptional(component)) {
+            if (!(component.typeName() instanceof ParameterizedTypeName)) {
+                return Optional.of(new OptionalType(optionalType, TypeName.get(Object.class)));
+            }
+            var parameterizedType = (ParameterizedTypeName) component.typeName();
+            final TypeName containingType = parameterizedType.typeArguments.isEmpty()
+                    ? TypeName.get(Object.class)
+                    : parameterizedType.typeArguments.get(0);
+            return Optional.of(new OptionalType(optionalType, containingType));
+        }
+        if (component.typeName().equals(optionalIntType)) {
+            return Optional.of(new OptionalType(optionalIntType, TypeName.get(int.class)));
+        }
+        if (component.typeName().equals(optionalLongType)) {
+            return Optional.of(new OptionalType(optionalLongType, TypeName.get(long.class)));
+        }
+        if (component.typeName().equals(optionalDoubleType)) {
+            return Optional.of(new OptionalType(optionalDoubleType, TypeName.get(double.class)));
+        }
+        return Optional.empty();
+    }
+}

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/RecordWithOptional.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/RecordWithOptional.java
@@ -22,6 +22,6 @@ import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 
-@RecordBuilder.Options(emptyDefaultForOptional = true)
+@RecordBuilder.Options(emptyDefaultForOptional = true, addConcreteSettersForOptional = true)
 @RecordBuilder
 public record RecordWithOptional(Optional<String> value, Optional raw, OptionalInt i, OptionalLong l, OptionalDouble d) {}

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/RecordWithOptional2.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/RecordWithOptional2.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2019 Jordan Zimmerman
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.soabase.recordbuilder.test;
+
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+import io.soabase.recordbuilder.core.RecordBuilder;
+
+@RecordBuilder.Options(emptyDefaultForOptional = true)
+@RecordBuilder
+public record RecordWithOptional2(Optional<String> value, Optional raw, OptionalInt i, OptionalLong l, OptionalDouble d) {}

--- a/record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestOptional.java
+++ b/record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestOptional.java
@@ -33,4 +33,20 @@ class TestOptional {
         Assertions.assertEquals(OptionalLong.empty(), record.l());
         Assertions.assertEquals(OptionalDouble.empty(), record.d());
     }
+
+    @Test
+    void testRawSetters() {
+        var record = RecordWithOptionalBuilder.builder()
+                .value("value")
+                .raw("rawValue")
+                .i(42)
+                .l(424242L)
+                .d(42.42)
+                .build();
+        Assertions.assertEquals(Optional.of("value"), record.value());
+        Assertions.assertEquals(Optional.of("rawValue"), record.raw());
+        Assertions.assertEquals(OptionalInt.of(42), record.i());
+        Assertions.assertEquals(OptionalLong.of(424242L), record.l());
+        Assertions.assertEquals(OptionalDouble.of(42.42), record.d());
+    }
 }

--- a/record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestOptional.java
+++ b/record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestOptional.java
@@ -49,4 +49,20 @@ class TestOptional {
         Assertions.assertEquals(OptionalLong.of(424242L), record.l());
         Assertions.assertEquals(OptionalDouble.of(42.42), record.d());
     }
+
+    @Test
+    void testOptionalSetters() {
+        var record = RecordWithOptional2Builder.builder()
+            .value(Optional.of("value"))
+            .raw(Optional.of("rawValue"))
+            .i(OptionalInt.of(42))
+            .l(OptionalLong.of(424242L))
+            .d(OptionalDouble.of(42.42))
+            .build();
+        Assertions.assertEquals(Optional.of("value"), record.value());
+        Assertions.assertEquals(Optional.of("rawValue"), record.raw());
+        Assertions.assertEquals(OptionalInt.of(42), record.i());
+        Assertions.assertEquals(OptionalLong.of(424242L), record.l());
+        Assertions.assertEquals(OptionalDouble.of(42.42), record.d());
+    }
 }


### PR DESCRIPTION
In my adventure to replace Immutables.org, I stumbled upon yet another nifty feature:

If you are setting an optional field, you are probably intending to set a concrete value.

So here is this PR that adds setters that take concrete values and wrap them in optional prior to insertion into the record.