### PR TITLE
Make withers and getters optional features

### DIFF
--- a/record-builder-core/src/main/java/io/soabase/recordbuilder/core/RecordBuilder.java
+++ b/record-builder-core/src/main/java/io/soabase/recordbuilder/core/RecordBuilder.java
@@ -100,6 +100,11 @@ public @interface RecordBuilder {
         String componentsMethodName() default "stream";
 
         /**
+         * If true, a "With" interface is generated and an associated static factory
+         */
+        boolean enableWither() default true;
+
+        /**
          * The name to use for the nested With class
          */
         String withClassName() default "With";
@@ -194,6 +199,11 @@ public @interface RecordBuilder {
          * a corresponding setter named "setMyField".
          */
         String setterPrefix() default "";
+
+        /**
+         * If true, getters will be generated for the Builder class.
+         */
+        boolean enableGetters() default true;
 
         /**
          * If set, all builder getter methods will be prefixed with this string. Camel-casing will

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/InternalRecordBuilderProcessor.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/InternalRecordBuilderProcessor.java
@@ -72,7 +72,9 @@ class InternalRecordBuilderProcessor {
                 .addAnnotation(generatedRecordBuilderAnnotation)
                 .addTypeVariables(typeVariables);
         addVisibility(recordActualPackage.equals(packageName), record.getModifiers());
-        addWithNestedClass();
+        if (metaData.enableWither()) {
+            addWithNestedClass();
+        }
         if (!metaData.beanClassName().isEmpty()) {
             addBeanNestedClass();
         }
@@ -83,7 +85,9 @@ class InternalRecordBuilderProcessor {
         }
         addStaticDefaultBuilderMethod();
         addStaticCopyBuilderMethod();
-        addStaticFromWithMethod();
+        if (metaData.enableWither()) {
+            addStaticFromWithMethod();
+        }
         addStaticComponentsMethod();
         addBuildMethod();
         addToStringMethod();
@@ -92,7 +96,9 @@ class InternalRecordBuilderProcessor {
         recordComponents.forEach(component -> {
             add1Field(component);
             add1SetterMethod(component);
-            add1GetterMethod(component);
+            if (metaData.enableGetters()) {
+                add1GetterMethod(component);
+            }
             var collectionMetaData = collectionBuilderUtils.singleItemsMetaData(component, EXCLUDE_WILDCARD_TYPES);
             collectionMetaData.ifPresent(meta -> add1CollectionBuilders(meta, component));
         });

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/StrippedFeaturesRecord.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/StrippedFeaturesRecord.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2019 Jordan Zimmerman
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.soabase.recordbuilder.test;
+
+import io.soabase.recordbuilder.core.RecordBuilder;
+
+@RecordBuilder
+@RecordBuilder.Options(
+    enableGetters = false,
+    enableWither = false
+)
+public record StrippedFeaturesRecord(int aField) {}


### PR DESCRIPTION
My generated builders are getting rather large for huge records and it is an unnecessary strain on javac. Additionally, this can be a problem for e.g. android users that want to limit their app sizes and avoid the upper limits of class count in DEX.

I was intending on making the enableGetters=false flag also remove the getters on the wither, but that turned out to be a bit of an adventure in rewrite, so I omitted that particular part just to keep the PR small.