### PR TITLE
Don't include `@Valid` on base interfaces

### DIFF
--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/RequestWithValid.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/RequestWithValid.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2019 Jordan Zimmerman
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.soabase.recordbuilder.test;
+
+import io.soabase.recordbuilder.core.RecordBuilder;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+@RecordBuilder
+@RecordBuilder.Options(useValidationApi = true)
+public record RequestWithValid(@NotNull @Valid Part part) implements RequestWithValidBuilder.With {
+  public record Part(@NotBlank String name) {}
+}

--- a/record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestValidation.java
+++ b/record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestValidation.java
@@ -43,4 +43,14 @@ class TestValidation {
         var valid = RequiredRecord2Builder.builder().hey("hey").i(1).build();
         Assertions.assertThrows(ValidationException.class, () -> valid.withHey(null));
     }
+
+    @Test
+    void testRequestWithValid() {
+        Assertions.assertDoesNotThrow(() -> RequestWithValidBuilder.builder()
+                .part(new RequestWithValid.Part("jsfjsf"))
+                .build());
+        Assertions.assertThrows(ValidationException.class, () -> RequestWithValidBuilder.builder()
+                .part(new RequestWithValid.Part(""))
+                .build());
+    }
 }


### PR DESCRIPTION
The validation API doesn't accept `@Valid` on base interfaces. Filter
them out.

Fixes #97