### PR TITLE
Options/changes so that Jacoco checks don't fail

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,8 @@
         <maven-jar-plugin-version>3.2.0</maven-jar-plugin-version>
         <maven-surefire-plugin-version>3.0.0-M5</maven-surefire-plugin-version>
 
+        <jacoco-maven-plugin-version>0.8.7</jacoco-maven-plugin-version>
+
         <license-file-path>src/etc/header.txt</license-file-path>
 
         <javapoet-version>1.12.1</javapoet-version>
@@ -325,6 +327,12 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-gpg-plugin</artifactId>
                     <version>${maven-gpg-plugin-version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>${jacoco-maven-plugin-version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/record-builder-core/src/main/java/io/soabase/recordbuilder/core/RecordBuilder.java
+++ b/record-builder-core/src/main/java/io/soabase/recordbuilder/core/RecordBuilder.java
@@ -234,6 +234,18 @@ public @interface RecordBuilder {
          * this option does nothing.
          */
         String beanClassName() default "";
+
+        /**
+         * If true, generated classes are annotated with {@code RecordBuilderGenerated} which has a retention
+         * policy of {@code CLASS}. This ensures that analyzers such as Jacoco will ignore the generated class.
+         */
+        boolean addClassRetainedGenerated() default false;
+
+        /**
+         * The {@link #fromMethodName} method instantiates an internal private class. This is the
+         * name of that class.
+         */
+        String fromWithClassName() default "_FromWith";
     }
 
     @Retention(RetentionPolicy.CLASS)

--- a/record-builder-core/src/main/java/io/soabase/recordbuilder/core/RecordBuilderGenerated.java
+++ b/record-builder-core/src/main/java/io/soabase/recordbuilder/core/RecordBuilderGenerated.java
@@ -15,21 +15,16 @@
  */
 package io.soabase.recordbuilder.core;
 
-import java.lang.annotation.*;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-@RecordBuilder.Template(options = @RecordBuilder.Options(
-        interpretNotNulls = true,
-        useImmutableCollections = true,
-        addSingleItemCollectionBuilders = true,
-        addFunctionalMethodsToWith = true,
-        addClassRetainedGenerated = true
-))
-@Retention(RetentionPolicy.SOURCE)
-@Target(ElementType.TYPE)
-@Inherited
+import static java.lang.annotation.ElementType.*;
+
 /**
- * An alternate form of {@code @RecordBuilder} that has most
- * optional features turned on
+ * Jacoco ignores classes and methods annotated with `*Generated`
  */
-public @interface RecordBuilderFull {
+@Target({PACKAGE, TYPE, METHOD, CONSTRUCTOR, FIELD, LOCAL_VARIABLE, PARAMETER})
+@Retention(RetentionPolicy.CLASS)
+public @interface RecordBuilderGenerated {
 }

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/InternalRecordInterfaceProcessor.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/InternalRecordInterfaceProcessor.java
@@ -33,6 +33,7 @@ import java.util.stream.Collectors;
 
 import static io.soabase.recordbuilder.processor.ElementUtils.getBuilderName;
 import static io.soabase.recordbuilder.processor.RecordBuilderProcessor.generatedRecordInterfaceAnnotation;
+import static io.soabase.recordbuilder.processor.RecordBuilderProcessor.recordBuilderGeneratedAnnotation;
 
 class InternalRecordInterfaceProcessor {
     private final ProcessingEnvironment processingEnv;
@@ -68,6 +69,9 @@ class InternalRecordInterfaceProcessor {
                 .addModifiers(Modifier.PUBLIC)
                 .addAnnotation(generatedRecordInterfaceAnnotation)
                 .addTypeVariables(typeVariables);
+        if (metaData.addClassRetainedGenerated()) {
+            builder.addAnnotation(recordBuilderGeneratedAnnotation);
+        }
 
         if (addRecordBuilder) {
             ClassType builderClassType = ElementUtils.getClassType(packageName, getBuilderName(iface, metaData, recordClassType, metaData.suffix()) + "." + metaData.withClassName(), iface.getTypeParameters());

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/RecordBuilderProcessor.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/RecordBuilderProcessor.java
@@ -19,6 +19,7 @@ import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.JavaFile;
 import com.squareup.javapoet.TypeSpec;
 import io.soabase.recordbuilder.core.RecordBuilder;
+import io.soabase.recordbuilder.core.RecordBuilderGenerated;
 import io.soabase.recordbuilder.core.RecordInterface;
 
 import javax.annotation.processing.AbstractProcessor;
@@ -46,6 +47,7 @@ public class RecordBuilderProcessor
 
     static final AnnotationSpec generatedRecordBuilderAnnotation = AnnotationSpec.builder(Generated.class).addMember("value", "$S", RecordBuilder.class.getName()).build();
     static final AnnotationSpec generatedRecordInterfaceAnnotation = AnnotationSpec.builder(Generated.class).addMember("value", "$S", RecordInterface.class.getName()).build();
+    static final AnnotationSpec recordBuilderGeneratedAnnotation = AnnotationSpec.builder(RecordBuilderGenerated.class).build();
 
     @Override
     public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {

--- a/record-builder-test/pom.xml
+++ b/record-builder-test/pom.xml
@@ -66,6 +66,48 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report</id>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>io/soabase/recordbuilder/test/jacoco/*</include>
+                            </includes>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.60</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/jacoco/FullRecordForJacoco.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/jacoco/FullRecordForJacoco.java
@@ -13,23 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.soabase.recordbuilder.core;
+package io.soabase.recordbuilder.test.jacoco;
 
-import java.lang.annotation.*;
+import io.soabase.recordbuilder.core.RecordBuilderFull;
+import io.soabase.recordbuilder.core.RecordBuilderGenerated;
 
-@RecordBuilder.Template(options = @RecordBuilder.Options(
-        interpretNotNulls = true,
-        useImmutableCollections = true,
-        addSingleItemCollectionBuilders = true,
-        addFunctionalMethodsToWith = true,
-        addClassRetainedGenerated = true
-))
-@Retention(RetentionPolicy.SOURCE)
-@Target(ElementType.TYPE)
-@Inherited
-/**
- * An alternate form of {@code @RecordBuilder} that has most
- * optional features turned on
- */
-public @interface RecordBuilderFull {
+import javax.validation.constraints.NotNull;
+import java.util.List;
+import java.util.Map;
+
+@RecordBuilderFull
+@RecordBuilderGenerated
+public record FullRecordForJacoco(@NotNull List<Number> numbers, @NotNull Map<Number, FullRecordForJacoco> fullRecords, @NotNull String justAString) {
 }


### PR DESCRIPTION
- Added new optional Annotation `@RecordBuilderGenerated` - Jacoco ignores
classes with any annotation names "\*Generated\*" but it needs to be class retained.
For backward compatibility this annotation is not added by default (though it's been
added to `@RecordBuilderFull`). There is a new option to enable it.
- The from with method now uses an internal static class instead of an anonymous
inner class so that the annotation can be on this as well. This new class's name
is configurable in the options.

Thanks to user @madisparn for initial PR and issue report.

Fixes #87 