### PR TITLE
`TYPE_USE` annotations were being ignored

### DIFF
--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/InternalRecordBuilderProcessor.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/InternalRecordBuilderProcessor.java
@@ -139,9 +139,9 @@ class InternalRecordBuilderProcessor {
     }
 
     private List<RecordClassType> buildRecordComponents(TypeElement record) {
-        var accessorAnnotations = record.getRecordComponents().stream().map(e -> e.getAccessor().getAnnotationMirrors()).collect(Collectors.toList());
-        var canonicalConstructorAnnotations = ElementUtils.findCanonicalConstructor(record).map(constructor -> ((ExecutableElement) constructor).getParameters().stream().map(Element::getAnnotationMirrors).collect(Collectors.toList())).orElse(List.of());
         var recordComponents = record.getRecordComponents();
+        var accessorAnnotations = recordComponents.stream().map(e -> e.asType().getAnnotationMirrors()).toList();
+        var canonicalConstructorAnnotations = ElementUtils.findCanonicalConstructor(record).map(constructor -> ((ExecutableElement) constructor).getParameters().stream().map(e -> e.asType().getAnnotationMirrors()).collect(Collectors.toList())).orElse(List.of());
         return IntStream.range(0, recordComponents.size())
                 .mapToObj(index -> {
                     var thisAccessorAnnotations = (accessorAnnotations.size() > index) ? accessorAnnotations.get(index) : List.<AnnotationMirror>of();

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/typeuse/MyFullRecord.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/typeuse/MyFullRecord.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2019 Jordan Zimmerman
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.soabase.recordbuilder.test.typeuse;
+
+import io.soabase.recordbuilder.core.RecordBuilderFull;
+
+@RecordBuilderFull
+public record MyFullRecord(@TypeUseNonNull String nonNullS) {
+}

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/typeuse/MyRecord.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/typeuse/MyRecord.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2019 Jordan Zimmerman
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.soabase.recordbuilder.test.typeuse;
+
+import io.soabase.recordbuilder.core.RecordBuilder;
+
+@RecordBuilder
+public record MyRecord(@TypeUseNonNull String nonNullS) {
+}

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/typeuse/TypeUseNonNull.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/typeuse/TypeUseNonNull.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2019 Jordan Zimmerman
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.soabase.recordbuilder.test.typeuse;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Documented
+@Retention(value = RUNTIME)
+@Target(value = {TYPE_USE, RECORD_COMPONENT, TYPE_PARAMETER})
+public @interface TypeUseNonNull {
+}


### PR DESCRIPTION
Java's DAG for annotations processors doesn't contain `TYPE_USE` annotations
on the Element for some reason. However, they are on the type. So, use the
type instead.

Note due to limitations of JavaPoet this doesn't fix `TYPE_USE` annotations on
parameterized types or array components. If we want to address those we will need
changes in JavaPoet which has been dormant for a very long time.

Fixes #113
Relates to #111