### PR TITLE
Collection copying only when changed

### DIFF
--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/CollectionBuilderUtils.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/CollectionBuilderUtils.java
@@ -280,7 +280,7 @@ class CollectionBuilderUtils {
     private MethodSpec buildMutableMakerMethod(String name, TypeName mutableCollectionType, ParameterizedTypeName parameterizedType, TypeVariableName... typeVariables) {
         var nullCase = CodeBlock.of("if (o == null) return new $T<>()", mutableCollectionType);
         var isMutableCase = CodeBlock.of("if (o instanceof $T) return o", mutableCollectionType);
-        var defaultCase = CodeBlock.of("return new $T(o)", mutableCollectionType);
+        var defaultCase = CodeBlock.of("return new $T<>(o)", mutableCollectionType);
         return MethodSpec.methodBuilder(name)
                 .addAnnotation(generatedRecordBuilderAnnotation)
                 .addModifiers(Modifier.PRIVATE, Modifier.STATIC)

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/CollectionBuilderUtils.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/CollectionBuilderUtils.java
@@ -144,7 +144,7 @@ class CollectionBuilderUtils {
         return component.rawTypeName().equals(setType);
     }
 
-    void add(CodeBlock.Builder builder, RecordClassType component) {
+    void addShimCall(CodeBlock.Builder builder, RecordClassType component) {
         if (useImmutableCollections) {
             if (isList(component)) {
                 needsListShim = true;
@@ -166,6 +166,20 @@ class CollectionBuilderUtils {
             }
         } else {
             builder.add("$L", component.name());
+        }
+    }
+
+    String shimName(RecordClassType component) {
+        if (isList(component)) {
+            return listShimName;
+        } else if (isMap(component)) {
+            return mapShimName;
+        } else if (isSet(component)) {
+            return setShimName;
+        } else if (component.rawTypeName().equals(collectionType)) {
+            return collectionShimName;
+        } else {
+            throw new IllegalArgumentException(component + " is not a supported collection type");
         }
     }
 

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/InternalRecordBuilderProcessor.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/InternalRecordBuilderProcessor.java
@@ -16,8 +16,6 @@
 package io.soabase.recordbuilder.processor;
 
 import static io.soabase.recordbuilder.processor.CollectionBuilderUtils.SingleItemsMetaDataMode.EXCLUDE_WILDCARD_TYPES;
-import static io.soabase.recordbuilder.processor.CollectionBuilderUtils.SingleItemsMetaDataMode.STANDARD;
-import static io.soabase.recordbuilder.processor.CollectionBuilderUtils.SingleItemsMetaDataMode.STANDARD_FOR_SETTER;
 import static io.soabase.recordbuilder.processor.ElementUtils.getBuilderName;
 import static io.soabase.recordbuilder.processor.ElementUtils.getWithMethodName;
 import static io.soabase.recordbuilder.processor.RecordBuilderProcessor.generatedRecordBuilderAnnotation;
@@ -112,6 +110,7 @@ class InternalRecordBuilderProcessor {
             collectionMetaData.ifPresent(meta -> add1CollectionBuilders(meta, component));
         });
         collectionBuilderUtils.addShims(builder);
+        collectionBuilderUtils.addMutableMakers(builder);
         builderType = builder.build();
     }
 
@@ -417,9 +416,7 @@ class InternalRecordBuilderProcessor {
                 .addAnnotation(generatedRecordBuilderAnnotation);
         recordComponents.forEach(component -> {
             constructorBuilder.addParameter(component.typeName(), component.name());
-            var collectionMetaData = collectionBuilderUtils.singleItemsMetaData(component, STANDARD);
-            collectionMetaData.ifPresentOrElse(meta -> constructorBuilder.addStatement("this.$L = new $T<>($L)", component.name(), meta.singleItemCollectionClass(), component.name()),
-                    () -> constructorBuilder.addStatement("this.$L = $L", component.name(), component.name()));
+            constructorBuilder.addStatement("this.$L = $L", component.name(), component.name());
         });
         builder.addMethod(constructorBuilder.build());
     }
@@ -819,34 +816,34 @@ class InternalRecordBuilderProcessor {
             For a single map record component, add a methods similar to:
 
             public T addP(K key, V value) {
-                if (this.p == null) {
-                    this.p = new HashMap<>();
-                }
+                this.p = __ensureMapMutable(p);
                 this.p.put(key, value);
                 return this;
             }
 
             public T addP(Stream<? extends Map.Entry<K, V> i) {
-                if (p == null) {
-                    p = new HashMap<>();
-                }
+                this.p = __ensureMapMutable(p);
                 i.forEach(this.p::put);
                 return this;
             }
 
             public T addP(Iterable<? extends Map.Entry<K, V> i) {
-                if (p == null) {
-                    p = new HashMap<>();
-                }
+                this.p = __ensureMapMutable(p);
                 i.forEach(this.p::put);
                 return this;
             }
          */
         for (var i = 0; i < 3; ++i) {
-            var codeBlockBuilder = CodeBlock.builder()
-                    .beginControlFlow("if (this.$L == null)", component.name())
-                    .addStatement("this.$L = new $T<>()", component.name(), HashMap.class)
-                    .endControlFlow();
+            var codeBlockBuilder = CodeBlock.builder();
+            if (collectionBuilderUtils.isImmutableCollection(component)) {
+                codeBlockBuilder
+                        .addStatement("this.$L = $L($L)", component.name(), collectionBuilderUtils.mutableMakerName(component), component.name());
+            } else {
+                codeBlockBuilder
+                        .beginControlFlow("if (this.$L == null)", component.name())
+                        .addStatement("this.$L = new $T<>()", component.name(), meta.singleItemCollectionClass())
+                        .endControlFlow();
+            }
             var methodSpecBuilder = MethodSpec.methodBuilder(metaData.singleItemBuilderPrefix() + capitalize(component.name()))
                     .addJavadoc("Add to the internally allocated {@code HashMap} for {@code $L}\n", component.name())
                     .addModifiers(Modifier.PUBLIC)
@@ -874,25 +871,19 @@ class InternalRecordBuilderProcessor {
             For a single list or set record component, add methods similar to:
 
             public T addP(I i) {
-                if (this.p == null) {
-                    this.p = new ArrayList<>();
-                }
+                this.list = __ensureListMutable(list);
                 this.p.add(i);
                 return this;
             }
 
             public T addP(Stream<? extends I> i) {
-                if (this.p == null) {
-                    this.p = new ArrayList<>();
-                }
+                this.list = __ensureListMutable(list);
                 this.p.addAll(i);
                 return this;
             }
 
             public T addP(Iterable<? extends I> i) {
-                if (this.p == null) {
-                    this.p = new ArrayList<>();
-                }
+                this.list = __ensureListMutable(list);
                 this.p.addAll(i);
                 return this;
             }
@@ -908,10 +899,17 @@ class InternalRecordBuilderProcessor {
                 var parameterClass = ClassName.get((i == 1) ? Stream.class : Iterable.class);
                 parameter = ParameterizedTypeName.get(parameterClass, WildcardTypeName.subtypeOf(meta.typeArguments().get(0)));
             }
-            var codeBlockBuilder = CodeBlock.builder()
-                    .beginControlFlow("if (this.$L == null)", component.name())
-                    .addStatement("this.$L = new $T<>()", component.name(), meta.singleItemCollectionClass())
-                    .endControlFlow()
+            var codeBlockBuilder = CodeBlock.builder();
+            if (collectionBuilderUtils.isImmutableCollection(component)) {
+                codeBlockBuilder
+                        .addStatement("this.$L = $L($L)", component.name(), collectionBuilderUtils.mutableMakerName(component), component.name());
+            } else {
+                codeBlockBuilder
+                        .beginControlFlow("if (this.$L == null)", component.name())
+                        .addStatement("this.$L = new $T<>()", component.name(), meta.singleItemCollectionClass())
+                        .endControlFlow();
+            }
+            codeBlockBuilder
                     .add(addClockBlock.build())
                     .addStatement("return this");
             var methodSpecBuilder = MethodSpec.methodBuilder(metaData.singleItemBuilderPrefix() + capitalize(component.name()))
@@ -957,19 +955,10 @@ class InternalRecordBuilderProcessor {
                 .addAnnotation(generatedRecordBuilderAnnotation)
                 .returns(builderClassType.typeName());
 
-        var collectionMetaData = collectionBuilderUtils.singleItemsMetaData(component, STANDARD_FOR_SETTER);
-        var parameterSpecBuilder = collectionMetaData.map(meta -> {
-            CodeBlock.Builder codeSpec = CodeBlock.builder();
-            codeSpec.addStatement("this.$L = ($L != null) ? new $T<>($L) : null", component.name(), component.name(), meta.singleItemCollectionClass(), component.name());
-            methodSpec.addJavadoc("Re-create the internally allocated {@code $L} for {@code $L} by copying the argument\n", meta.singleItemCollectionClass().getSimpleName(), component.name())
-                    .addCode(codeSpec.build());
-            return ParameterSpec.builder(meta.wildType(), component.name());
-        }).orElseGet(() -> {
-            methodSpec.addJavadoc("Set a new value for the {@code $L} record component in the builder\n", component.name())
-                    .addStatement("this.$L = $L", component.name(), component.name());
-            return ParameterSpec.builder(component.typeName(), component.name());
-        });
+        var parameterSpecBuilder = ParameterSpec.builder(component.typeName(), component.name());
         addConstructorAnnotations(component, parameterSpecBuilder);
+        methodSpec.addJavadoc("Set a new value for the {@code $L} record component in the builder\n", component.name());
+        methodSpec.addStatement("this.$L = $L", component.name(), component.name());
         methodSpec.addStatement("return this").addParameter(parameterSpecBuilder.build());
         builder.addMethod(methodSpec.build());
     }

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/InternalRecordBuilderProcessor.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/InternalRecordBuilderProcessor.java
@@ -971,13 +971,6 @@ class InternalRecordBuilderProcessor {
         addConstructorAnnotations(component, parameterSpecBuilder);
         methodSpec.addStatement("return this").addParameter(parameterSpecBuilder.build());
         builder.addMethod(methodSpec.build());
-
-//        var parameterSpecBuilder = ParameterSpec.builder(component.typeName(), component.name());
-//        addConstructorAnnotations(component, parameterSpecBuilder);
-//        methodSpec.addJavadoc("Set a new value for the {@code $L} record component in the builder\n", component.name());
-//        methodSpec.addStatement("this.$L = $L", component.name(), component.name());
-//        methodSpec.addStatement("return this").addParameter(parameterSpecBuilder.build());
-//        builder.addMethod(methodSpec.build());
     }
 
     private void add1ConcreteOptionalSetterMethod(RecordClassType component) {

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/CollectionCopying.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/CollectionCopying.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2019 Jordan Zimmerman
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/CollectionCopying.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/CollectionCopying.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2019 Jordan Zimmerman
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.soabase.recordbuilder.test;
+
+import io.soabase.recordbuilder.core.RecordBuilder;
+
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@RecordBuilder
+@RecordBuilder.Options(
+        addSingleItemCollectionBuilders = true,
+        useImmutableCollections = true
+)
+public record CollectionCopying<T>(List<String> list, Set<T> set, Map<Instant, T> map, Collection<T> collection,
+                                   int count) implements CollectionCopyingBuilder.With<T> {
+}

--- a/record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestCollections.java
+++ b/record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestCollections.java
@@ -27,7 +27,7 @@ class TestCollections {
     @Test
     void testRecordBuilderOptionsCopied() {
         try {
-            assertNotNull(CollectionInterfaceRecordBuilder.class.getDeclaredMethod("__list", List.class));
+            assertNotNull(CollectionInterfaceRecordBuilder.class.getDeclaredMethod("__list", Collection.class));
         } catch (NoSuchMethodException e) {
             Assertions.fail(e);
         }

--- a/record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestImmutableCollections.java
+++ b/record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestImmutableCollections.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2019 Jordan Zimmerman
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.soabase.recordbuilder.test;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class TestImmutableCollections {
+    @Test
+    public void testImmutableCollectionNotCopiedWhenNotChanged() {
+        var item = CollectionCopyingBuilder.<String>builder()
+                .addMap(Instant.MAX, "future")
+                .addMap(Instant.MIN, "before")
+                .addSet(Arrays.asList("1", "2", "3"))
+                .addList("a")
+                .addList("b")
+                .addList("c")
+                .collection(List.of("foo", "bar", "baz"))
+                .build();
+        Assertions.assertEquals(item.map(), Map.of(Instant.MAX, "future", Instant.MIN, "before"));
+        Assertions.assertEquals(item.set(), Set.of("1", "2", "3"));
+        Assertions.assertEquals(item.list(), List.of("a", "b", "c"));
+        Assertions.assertEquals(item.collection(), List.of("foo", "bar", "baz"));
+
+        var oldList = item.list();
+        var oldSet = item.set();
+        var oldMap = item.map();
+
+        var copy = item.with()
+                .count(1)
+                .build();
+
+        Assertions.assertSame(oldList, copy.list());
+        Assertions.assertSame(oldSet, copy.set());
+        Assertions.assertSame(oldMap, copy.map());
+
+        var otherCopy = item.withCount(2);
+        Assertions.assertSame(oldList, otherCopy.list());
+        Assertions.assertSame(oldSet, otherCopy.set());
+        Assertions.assertSame(oldMap, otherCopy.map());
+    }
+}


### PR DESCRIPTION
For #114 

Currently the test `TestCollections.testRecordBuilderOptionsCopied` fails, since I had to change the signature of the `__list()` shim methods. The problem is, that the code as on master generates setters for collections with different signatures: 
If `addSingleItemCollectionBuilders == true`: `someList(Collection<? extends ListItem> someList)`, but otherwise the `someList` parameter is of type `List<...>`. I didn't want to change that behavior together with the other ticket, though (see #117 ).