### PR TITLE
Fix addSingleItemCollectionBuilders when useImmutableCollections is false

### DIFF
--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/issue129/CombinedFields.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/issue129/CombinedFields.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2019 Jordan Zimmerman
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.soabase.recordbuilder.test.issue129;
+
+import java.util.List;
+import java.util.Map;
+
+@RecordStyle
+public record CombinedFields<K, V>(
+        Map<K, V> kvMap,
+        String combinedField,
+        List<String> lines) implements CombinedFieldsBuilder.Bean<K, V>, CombinedFieldsBuilder.With<K, V> {
+}

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/issue129/RecordStyle.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/issue129/RecordStyle.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2019 Jordan Zimmerman
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.soabase.recordbuilder.test.issue129;
+
+import io.soabase.recordbuilder.core.RecordBuilder;
+
+import java.lang.annotation.*;
+
+@RecordBuilder.Template(options = @RecordBuilder.Options(
+    addSingleItemCollectionBuilders = true,
+    addFunctionalMethodsToWith = true,
+    booleanPrefix = "is",
+    setterPrefix = "set",
+    beanClassName = "Bean"))
+@Retention(RetentionPolicy.SOURCE)
+@Target(ElementType.TYPE)
+@Inherited
+public @interface RecordStyle {
+
+}


### PR DESCRIPTION
- Removed `SingleItemsMetaDataMode.STANDARD` as it wasn't used
- Removed `needs*MutableMaker` - always add them when corresponding `needs*Shim` is true
- Merged `addMutableMakers()` into `addShims()`
- Always use mutable makers when addSingleItemCollectionBuilders is true

Fixes #129

cc @mads-b, @freelon, @tmichel