### PR TITLE
feat: add optional suffix to static builder

### DIFF
--- a/record-builder-core/src/main/java/io/soabase/recordbuilder/core/RecordBuilder.java
+++ b/record-builder-core/src/main/java/io/soabase/recordbuilder/core/RecordBuilder.java
@@ -254,6 +254,12 @@ public @interface RecordBuilder {
         boolean addStaticBuilder() default true;
 
         /**
+         * If set, appends a suffix to the static builder method
+         */
+        String staticBuilderSuffix() default "";
+
+
+        /**
          * If {@link #addSingleItemCollectionBuilders()} and {@link #useImmutableCollections()} are enabled the builder
          * uses an internal class to track changes to lists. This is the name of that class.
          */

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/InternalRecordBuilderProcessor.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/InternalRecordBuilderProcessor.java
@@ -363,7 +363,7 @@ class InternalRecordBuilderProcessor {
             }
          */
         CodeBlock codeBlock = buildCodeBlock();
-        var builder = MethodSpec.methodBuilder(recordClassType.name())
+        var builder = MethodSpec.methodBuilder(recordClassType.name() + metaData.staticBuilderSuffix())
                 .addJavadoc("Static constructor/builder. Can be used instead of new $L(...)\n", recordClassType.name())
                 .addTypeVariables(typeVariables)
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)


### PR DESCRIPTION
Not sure what you think of this, my team are coming from using Immutables heavily and are fond of their FieldName.of() syntax convention for static builders.

I’m assuming my change would enable us to call a static builder like FieldNameBuilder.FieldNameOf().

When statically imported, would read succinctly as _FieldNameOf()_