### PR TITLE
Configurable modifiers on static builders

### DIFF
--- a/record-builder-core/src/main/java/io/soabase/recordbuilder/core/RecordBuilder.java
+++ b/record-builder-core/src/main/java/io/soabase/recordbuilder/core/RecordBuilder.java
@@ -15,6 +15,7 @@
  */
 package io.soabase.recordbuilder.core;
 
+import javax.lang.model.element.Modifier;
 import java.lang.annotation.*;
 
 @Retention(RetentionPolicy.SOURCE)
@@ -270,6 +271,13 @@ public @interface RecordBuilder {
          * uses an internal class to track changes to maps. This is the name of that class.
          */
         String mutableMapClassName() default "_MutableMap";
+
+
+        /**
+         * Any additional {@link javax.lang.model.element.Modifier} you wish to apply to the builder.  For example to
+         * make the builder public when the record is package protect.
+         */
+        Modifier[] builderClassModifiers() default {};
     }
 
     @Retention(RetentionPolicy.CLASS)

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/InternalRecordBuilderProcessor.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/InternalRecordBuilderProcessor.java
@@ -70,6 +70,7 @@ class InternalRecordBuilderProcessor {
 
         builder = TypeSpec.classBuilder(builderClassType.name())
                 .addAnnotation(generatedRecordBuilderAnnotation)
+                .addModifiers(metaData.builderClassModifiers())
                 .addTypeVariables(typeVariables);
         if (metaData.addClassRetainedGenerated()) {
             builder.addAnnotation(recordBuilderGeneratedAnnotation);

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/visibility/PackagePrivateRecordWithPublicBuilder.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/visibility/PackagePrivateRecordWithPublicBuilder.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2019 Jordan Zimmerman
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.soabase.recordbuilder.test.visibility;
+
+import io.soabase.recordbuilder.core.RecordBuilder;
+
+import javax.lang.model.element.Modifier;
+
+
+@RecordBuilder.Options(builderClassModifiers = {Modifier.PUBLIC})
+@RecordBuilder
+record PackagePrivateRecordWithPublicBuilder(String value) {
+}

--- a/record-builder-test/src/test/java/io/soabase/recordbuilder/test/visibility/TestVisibility.java
+++ b/record-builder-test/src/test/java/io/soabase/recordbuilder/test/visibility/TestVisibility.java
@@ -29,4 +29,15 @@ class TestVisibility {
 
         Assertions.assertTrue(Modifier.isPublic(WrapperProtectedRecordBuilder.class.getModifiers()));
     }
+
+
+    @Test
+    void testMatchesWithModifers() {
+        Assertions.assertFalse(Modifier.isPublic(PackagePrivateRecordWithPublicBuilder.class.getModifiers()));
+        Assertions.assertFalse(Modifier.isPrivate(PackagePrivateRecordWithPublicBuilder.class.getModifiers()));
+        Assertions.assertFalse(Modifier.isProtected(PackagePrivateRecordWithPublicBuilder.class.getModifiers()));
+
+        Assertions.assertTrue(Modifier.isPublic(PackagePrivateRecordWithPublicBuilderBuilder.class.getModifiers()));
+    }
+
 }


### PR DESCRIPTION
### The use case
Ensure people use the static builder and don't new up the record directly by restricting access to the records constructor.  This becomes more important when 50+ developers are working on the same code base, by using the compiler to help enforce the stylist approaches.

### Why Do we need this?

Currently with records we can't make the constructor private, it will have the same visibility as the record it's self.  In addition when using this library, the static builder will also have the same visibility as the record.

### What does this PR add?

This PR enables you to configure the modifiers on the static builder such that you can set the static builder to have a public modifier whereas the record is package-protect, so when your records are in a domain package they can't be accessed directly and new'ed up.

### Discussion points
 1. Do we want to make this configurable like in this PR or a simple boolean flag


### Outstanding work

Assuming you are happy with the principle and approach, I need to update the documentation.