### PR TITLE
Upgrade license-maven-plugin version and reformat

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2019 Jordan Zimmerman
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <maven-source-plugin-version>3.2.0</maven-source-plugin-version>
         <maven-install-plugin-version>2.5.2</maven-install-plugin-version>
         <maven-deploy-plugin-version>2.8.2</maven-deploy-plugin-version>
-        <maven-license-plugin-version>1.9.0</maven-license-plugin-version>
+        <maven-license-plugin-version>4.1</maven-license-plugin-version>
         <maven-gpg-plugin-version>1.6</maven-gpg-plugin-version>
         <maven-javadoc-plugin-version>3.1.1</maven-javadoc-plugin-version>
         <maven-clean-plugin-version>3.1.0</maven-clean-plugin-version>
@@ -195,8 +195,8 @@
                 </plugin>
 
                 <plugin>
-                    <groupId>com.mycila.maven-license-plugin</groupId>
-                    <artifactId>maven-license-plugin</artifactId>
+                    <groupId>com.mycila</groupId>
+                    <artifactId>license-maven-plugin</artifactId>
                     <version>${maven-license-plugin-version}</version>
                     <configuration>
                         <header>${license-file-path}</header>
@@ -356,8 +356,8 @@
             </plugin>
 
             <plugin>
-                <groupId>com.mycila.maven-license-plugin</groupId>
-                <artifactId>maven-license-plugin</artifactId>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
             </plugin>
 
             <plugin>

--- a/record-builder-core/pom.xml
+++ b/record-builder-core/pom.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2019 Jordan Zimmerman
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>io.soabase.record-builder</groupId>

--- a/record-builder-core/src/main/java/io/soabase/recordbuilder/core/IgnoreDefaultMethod.java
+++ b/record-builder-core/src/main/java/io/soabase/recordbuilder/core/IgnoreDefaultMethod.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-core/src/main/java/io/soabase/recordbuilder/core/RecordBuilder.java
+++ b/record-builder-core/src/main/java/io/soabase/recordbuilder/core/RecordBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-core/src/main/java/io/soabase/recordbuilder/core/RecordBuilderFull.java
+++ b/record-builder-core/src/main/java/io/soabase/recordbuilder/core/RecordBuilderFull.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-core/src/main/java/io/soabase/recordbuilder/core/RecordBuilderGenerated.java
+++ b/record-builder-core/src/main/java/io/soabase/recordbuilder/core/RecordBuilderGenerated.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-core/src/main/java/io/soabase/recordbuilder/core/RecordInterface.java
+++ b/record-builder-core/src/main/java/io/soabase/recordbuilder/core/RecordInterface.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-processor/pom.xml
+++ b/record-builder-processor/pom.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2019 Jordan Zimmerman
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>io.soabase.record-builder</groupId>

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/ClassType.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/ClassType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/CollectionBuilderUtils.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/CollectionBuilderUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/ElementUtils.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/ElementUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/IncludeHelper.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/IncludeHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/InternalRecordBuilderProcessor.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/InternalRecordBuilderProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/InternalRecordInterfaceProcessor.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/InternalRecordInterfaceProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/OptionalType.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/OptionalType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/RecordBuilderOptions.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/RecordBuilderOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/RecordBuilderProcessor.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/RecordBuilderProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/RecordClassType.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/RecordClassType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/pom.xml
+++ b/record-builder-test/pom.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2019 Jordan Zimmerman
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>io.soabase.record-builder</groupId>

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/Annotated.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/Annotated.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/BeanStyle.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/BeanStyle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/Builder.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/Builder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/CollectionCopying.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/CollectionCopying.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/CollectionInterface.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/CollectionInterface.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/CollectionRecord.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/CollectionRecord.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/CollectionRecordConflicts.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/CollectionRecordConflicts.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/CustomMethodNames.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/CustomMethodNames.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/Customer.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/Customer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/Empty.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/Empty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/ExceptionDetails.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/ExceptionDetails.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/FullRecord.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/FullRecord.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/HasDefaults.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/HasDefaults.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/IgnoreAnnotated.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/IgnoreAnnotated.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/IncludeWithOption.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/IncludeWithOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/InterfaceTemplateTest.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/InterfaceTemplateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/MutableCollectionRecord.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/MutableCollectionRecord.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/MyInterfaceTemplate.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/MyInterfaceTemplate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/MyTemplate.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/MyTemplate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/Nested.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/Nested.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/NoBuilder.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/NoBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/NoStaticBuilder.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/NoStaticBuilder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Jordan Zimmerman
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.soabase.recordbuilder.test;
 
 import io.soabase.recordbuilder.core.RecordBuilder;

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/Pair.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/Pair.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/Person.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/Person.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/Point.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/Point.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/RecordWithAnR.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/RecordWithAnR.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/RecordWithOptional.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/RecordWithOptional.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/RecordWithOptional2.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/RecordWithOptional2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/RequestWithValid.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/RequestWithValid.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/RequiredRecord.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/RequiredRecord.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/RequiredRecord2.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/RequiredRecord2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/SimpleGenericRecord.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/SimpleGenericRecord.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/SimpleRecord.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/SimpleRecord.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/SingleItems.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/SingleItems.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/SpecializedPerson.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/SpecializedPerson.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/StrippedFeaturesRecord.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/StrippedFeaturesRecord.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/TemplateTest.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/TemplateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/Thingy.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/Thingy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/Usage.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/Usage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/WildcardSingleItems.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/WildcardSingleItems.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/includes/IncludeFactory.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/includes/IncludeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/includes/JustATest.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/includes/JustATest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/includes/pack/AlsoIgnoreMe.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/includes/pack/AlsoIgnoreMe.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/includes/pack/IgnoreMe.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/includes/pack/IgnoreMe.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/includes/pack/PackRecord1.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/includes/pack/PackRecord1.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/includes/pack/PackRecord2.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/includes/pack/PackRecord2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/includes/pack/PackRecord3.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/includes/pack/PackRecord3.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/jacoco/FullRecordForJacoco.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/jacoco/FullRecordForJacoco.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/package-info.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 @RecordBuilder.Include(value = {Point.class, Pair.class}, packagePattern = "*.foo")
 @RecordInterface.Include(value = Customer.class, addRecordBuilder = false, packagePattern = "*.bar")
 package io.soabase.recordbuilder.test;

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/visibility/PackagePrivateRecord.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/visibility/PackagePrivateRecord.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/visibility/PackagePrivateRecordWithPublicBuilder.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/visibility/PackagePrivateRecordWithPublicBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/visibility/Wrapper.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/visibility/Wrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestAnnotated.java
+++ b/record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestAnnotated.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestCollections.java
+++ b/record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestCollections.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestCollectionsBuilder.java
+++ b/record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestCollectionsBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestImmutableCollections.java
+++ b/record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestImmutableCollections.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestIncludes.java
+++ b/record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestIncludes.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestOptional.java
+++ b/record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestOptional.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestRecordBuilderFull.java
+++ b/record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestRecordBuilderFull.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestRecordInterface.java
+++ b/record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestRecordInterface.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestSingleItems.java
+++ b/record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestSingleItems.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestTemplate.java
+++ b/record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestTemplate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestValidation.java
+++ b/record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestValidation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestVariousOptions.java
+++ b/record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestVariousOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestWithers.java
+++ b/record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestWithers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-test/src/test/java/io/soabase/recordbuilder/test/visibility/TestVisibility.java
+++ b/record-builder-test/src/test/java/io/soabase/recordbuilder/test/visibility/TestVisibility.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/record-builder-validator/pom.xml
+++ b/record-builder-validator/pom.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2019 Jordan Zimmerman
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>io.soabase.record-builder</groupId>

--- a/record-builder-validator/src/main/java/io/soabase/recordbuilder/validator/RecordBuilderValidator.java
+++ b/record-builder-validator/src/main/java/io/soabase/recordbuilder/validator/RecordBuilderValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Jordan Zimmerman
  *
  * Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
New version changes header style of java files from javadoc to slashstar, and thus we aren't bothered by IDE reformatting.