### PR TITLE
Issue #123: support nullable collections

### DIFF
--- a/record-builder-core/src/main/java/io/soabase/recordbuilder/core/RecordBuilder.java
+++ b/record-builder-core/src/main/java/io/soabase/recordbuilder/core/RecordBuilder.java
@@ -205,6 +205,16 @@ public @interface RecordBuilder {
         boolean useUnmodifiableCollections() default false;
 
         /**
+         * Adds special handling for record components of type: {@link java.util.List}, {@link java.util.Set},
+         * {@link java.util.Map} and {@link java.util.Collection}. When the record is built, any components of these
+         * types are passed through an added shim method that uses the corresponding immutable collection (e.g.
+         * {@code List.copyOf(o)}), or {@code null} if the component is {@code null}. If nulls are interpreted (see
+         * {@link #interpretNotNulls()}), the record component will return {@code null} only if it's NOT annotated by
+         * any of the not-null annotations (defined by {@link #interpretNotNullsPattern()}).
+         */
+        boolean allowNullableCollections() default false;
+
+        /**
          * When enabled, collection types ({@code List}, {@code Set} and {@code Map}) are handled specially. The setters
          * for these types now create an internal collection and items are added to that collection. Additionally,
          * "adder" methods prefixed with {@link #singleItemBuilderPrefix()} are created to add single items to these

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/CollectionBuilderUtils.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/CollectionBuilderUtils.java
@@ -26,7 +26,6 @@ import static io.soabase.recordbuilder.processor.RecordBuilderProcessor.generate
 import static io.soabase.recordbuilder.processor.RecordBuilderProcessor.recordBuilderGeneratedAnnotation;
 
 class CollectionBuilderUtils {
-
     private final boolean useImmutableCollections;
     private final boolean useUnmodifiableCollections;
     private final boolean allowNullableCollections;
@@ -410,7 +409,7 @@ class CollectionBuilderUtils {
                     collectionsTypeName, kType, vType, parameterizedType, collectionsTypeName, kType, vType);
         }
 
-        throw new IllegalStateException("Cannot build shim method for" + mainType);
+        throw new IllegalStateException("Cannot build shim method for " + mainType);
     }
 
     private MethodSpec buildNullableShimMethod(String name, TypeName mainType, Class<?> abstractType,
@@ -445,7 +444,7 @@ class CollectionBuilderUtils {
                     tType, parameterizedType);
         }
 
-        throw new IllegalStateException("Cannot build shim method for" + mainType);
+        throw new IllegalStateException("Cannot build shim method for " + mainType);
     }
 
     private MethodSpec buildMutableMakerMethod(String name, String mutableCollectionType,

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/RecordBuilderProcessor.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/RecordBuilderProcessor.java
@@ -198,10 +198,15 @@ public class RecordBuilderProcessor extends AbstractProcessor {
     private void validateMetaData(RecordBuilder.Options metaData, Element record) {
         var useImmutableCollections = metaData.useImmutableCollections();
         var useUnmodifiableCollections = metaData.useUnmodifiableCollections();
+        var allowNullableCollections = metaData.allowNullableCollections();
 
         if (useImmutableCollections && useUnmodifiableCollections) {
             processingEnv.getMessager().printMessage(Diagnostic.Kind.MANDATORY_WARNING,
                     "Options.useUnmodifiableCollections property is ignored as Options.useImmutableCollections is set to true",
+                    record);
+        } else if (!useImmutableCollections && !useUnmodifiableCollections && allowNullableCollections) {
+            processingEnv.getMessager().printMessage(Diagnostic.Kind.MANDATORY_WARNING,
+                    "Options.allowNullableCollections property will have no effect as Options.useImmutableCollections and Options.useUnmodifiableCollections are set to false",
                     record);
         }
     }

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/NonspecializedNullabeCollectionRecord.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/NonspecializedNullabeCollectionRecord.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 The original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.soabase.recordbuilder.test;
+
+import io.soabase.recordbuilder.core.RecordBuilder;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * To test that the compilation warning is emitted for this combination of options
+ */
+@RecordBuilder
+@RecordBuilder.Options(useImmutableCollections = false, useUnmodifiableCollections = false, allowNullableCollections = true)
+public record NonspecializedNullabeCollectionRecord<T, X extends Point>(List<T> l, Set<T> s, Map<T, X> m,
+        Collection<X> c) implements CollectionRecordBuilder.With<T, X> {
+
+}

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/NullableCollectionRecord.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/NullableCollectionRecord.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 The original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.soabase.recordbuilder.test;
+
+import io.soabase.recordbuilder.core.RecordBuilder;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@RecordBuilder
+@RecordBuilder.Options(useImmutableCollections = true, allowNullableCollections = true)
+public record NullableCollectionRecord<T, X extends Point>(List<T> l, Set<T> s, Map<T, X> m, Collection<X> c)
+        implements CollectionRecordBuilder.With<T, X> {
+
+}

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/NullableCollectionRecordInterpretingNotNulls.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/NullableCollectionRecordInterpretingNotNulls.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 The original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.soabase.recordbuilder.test;
+
+import io.soabase.recordbuilder.core.RecordBuilder;
+
+import javax.validation.constraints.NotNull;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@RecordBuilder
+@RecordBuilder.Options(useImmutableCollections = true, allowNullableCollections = true, interpretNotNulls = true)
+public record NullableCollectionRecordInterpretingNotNulls<T, X extends Point>(@NotNull List<T> l, Set<T> s,
+        Map<T, X> m, @NotNull Collection<X> c) implements CollectionRecordBuilder.With<T, X> {
+
+}

--- a/record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestNullableCollectionsBuilder.java
+++ b/record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestNullableCollectionsBuilder.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2019 The original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.soabase.recordbuilder.test;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class TestNullableCollectionsBuilder {
+
+    @Test
+    void testNullableCollectionsBuilder_returnsTheActualValuesIfSet() {
+        List<Object> list = List.of("list");
+        Set<Object> set = Set.of("set");
+        Collection<Point> collection = List.of(new Point(10, 20));
+        Map<Object, Point> map = Map.of("one", new Point(10, 20));
+
+        NullableCollectionRecordBuilder<Object, Point> builder = NullableCollectionRecordBuilder.builder().l(list)
+                .s(set).c(collection).m(map);
+
+        Assertions.assertEquals(list, builder.l());
+        Assertions.assertEquals(set, builder.s());
+        Assertions.assertEquals(collection, builder.c());
+        Assertions.assertEquals(map, builder.m());
+
+        var record = builder.build();
+        Assertions.assertEquals(list, record.l());
+        Assertions.assertEquals(set, record.s());
+        Assertions.assertEquals(collection, record.c());
+        Assertions.assertEquals(map, record.m());
+    }
+
+    @Test
+    void testNullableCollectionsBuilder_whenNullsAreNotInterpreted_returnsNullForAllComponents_whenNullsAreNotInterpreted() {
+        NullableCollectionRecordBuilder<Object, Point> builder = NullableCollectionRecordBuilder.builder();
+
+        Assertions.assertNull(builder.l());
+        Assertions.assertNull(builder.m());
+        Assertions.assertNull(builder.c());
+        Assertions.assertNull(builder.s());
+
+        var record = builder.build();
+        Assertions.assertNull(record.l());
+        Assertions.assertNull(record.m());
+        Assertions.assertNull(record.c());
+        Assertions.assertNull(record.s());
+    }
+
+    @Test
+    void testNullableCollectionBuilder_whenNullsAreInterpreted_returnsNullOrEmptyCollectionBasedOnComponentNullability() {
+        // NotNull - list, collection
+        // Nullable - set, map
+        NullableCollectionRecordInterpretingNotNullsBuilder<Object, Point> builder = NullableCollectionRecordInterpretingNotNullsBuilder
+                .builder();
+
+        Assertions.assertNotNull(builder.l());
+        Assertions.assertTrue(builder.l().isEmpty());
+
+        Assertions.assertNull(builder.m());
+        Assertions.assertNull(builder.s());
+
+        Assertions.assertNotNull(builder.c());
+        Assertions.assertTrue(builder.c().isEmpty());
+
+        var record = builder.build();
+        Assertions.assertNotNull(record.l());
+        Assertions.assertTrue(record.l().isEmpty());
+
+        Assertions.assertNull(record.m());
+        Assertions.assertNull(record.s());
+
+        Assertions.assertNotNull(record.c());
+        Assertions.assertTrue(record.c().isEmpty());
+    }
+}


### PR DESCRIPTION
Solves https://github.com/Randgalt/record-builder/issues/123

There's a new `allowNullableCollections` option that does the following:
- if set to `false` (default value for BC), does nothing
- if set to `true` and `interpretNotNulls = false`, a list/set/map/collection record component will return null if value is not set
- if set to `true` and `interpretNotNulls = true`, a list/set/map/collection record component will return null only if it's determined to be nullable, i.e. isn't annotated by any of the not-null patterns

All branches mentioned above should be covered by the `TestNullableCollectionsBuilder` test

