### PR TITLE
Fix -Xlint warnings in the generated code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,6 +193,9 @@
                     <version>${maven-compiler-plugin-version}</version>
                     <configuration>
                         <release>${jdk-version}</release>
+                        <compilerArgs>
+                            <arg>-Xlint:all</arg>
+                        </compilerArgs>
                     </configuration>
                 </plugin>
 

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/CollectionBuilderUtils.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/CollectionBuilderUtils.java
@@ -394,9 +394,6 @@ class CollectionBuilderUtils {
         return methodBuilder.addAnnotation(generatedRecordBuilderAnnotation)
                 .addModifiers(Modifier.PRIVATE, Modifier.STATIC).addTypeVariables(Arrays.asList(typeVariables))
                 .returns(parameterizedType).addParameter(extendedParameterizedType, "o").addStatement(code).build();
-                .addAnnotation(suppressWarningsAnnotation).addModifiers(Modifier.PRIVATE, Modifier.STATIC)
-                .addTypeVariables(Arrays.asList(typeVariables)).returns(parameterizedType)
-                .addParameter(extendedParameterizedType, "o").addStatement(code).build();
     }
 
     private CodeBlock buildShimMethodBody(TypeName mainType, ParameterizedTypeName parameterizedType) {

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/CollectionBuilderUtils.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/CollectionBuilderUtils.java
@@ -386,7 +386,14 @@ class CollectionBuilderUtils {
         TypeName[] wildCardTypeArguments = parameterizedType.typeArguments.stream().map(WildcardTypeName::subtypeOf)
                 .toList().toArray(new TypeName[0]);
         var extendedParameterizedType = ParameterizedTypeName.get(ClassName.get(abstractType), wildCardTypeArguments);
-        return MethodSpec.methodBuilder(name).addAnnotation(generatedRecordBuilderAnnotation)
+
+        MethodSpec.Builder methodBuilder = MethodSpec.methodBuilder(name);
+        if (!useImmutableCollections) {
+            methodBuilder.addAnnotation(suppressWarningsAnnotation);
+        }
+        return methodBuilder.addAnnotation(generatedRecordBuilderAnnotation)
+                .addModifiers(Modifier.PRIVATE, Modifier.STATIC).addTypeVariables(Arrays.asList(typeVariables))
+                .returns(parameterizedType).addParameter(extendedParameterizedType, "o").addStatement(code).build();
                 .addAnnotation(suppressWarningsAnnotation).addModifiers(Modifier.PRIVATE, Modifier.STATIC)
                 .addTypeVariables(Arrays.asList(typeVariables)).returns(parameterizedType)
                 .addParameter(extendedParameterizedType, "o").addStatement(code).build();

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/CollectionBuilderUtils.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/CollectionBuilderUtils.java
@@ -19,11 +19,13 @@ import com.squareup.javapoet.*;
 import io.soabase.recordbuilder.core.RecordBuilder;
 
 import javax.lang.model.element.Modifier;
+import java.io.Serial;
 import java.util.*;
 import java.util.regex.Pattern;
 
 import static io.soabase.recordbuilder.processor.RecordBuilderProcessor.generatedRecordBuilderAnnotation;
 import static io.soabase.recordbuilder.processor.RecordBuilderProcessor.recordBuilderGeneratedAnnotation;
+import static io.soabase.recordbuilder.processor.RecordBuilderProcessor.suppressWarningsAnnotation;
 
 class CollectionBuilderUtils {
     private final boolean useImmutableCollections;
@@ -385,8 +387,9 @@ class CollectionBuilderUtils {
                 .toList().toArray(new TypeName[0]);
         var extendedParameterizedType = ParameterizedTypeName.get(ClassName.get(abstractType), wildCardTypeArguments);
         return MethodSpec.methodBuilder(name).addAnnotation(generatedRecordBuilderAnnotation)
-                .addModifiers(Modifier.PRIVATE, Modifier.STATIC).addTypeVariables(Arrays.asList(typeVariables))
-                .returns(parameterizedType).addParameter(extendedParameterizedType, "o").addStatement(code).build();
+                .addAnnotation(suppressWarningsAnnotation).addModifiers(Modifier.PRIVATE, Modifier.STATIC)
+                .addTypeVariables(Arrays.asList(typeVariables)).returns(parameterizedType)
+                .addParameter(extendedParameterizedType, "o").addStatement(code).build();
     }
 
     private CodeBlock buildShimMethodBody(TypeName mainType, ParameterizedTypeName parameterizedType) {
@@ -467,6 +470,9 @@ class CollectionBuilderUtils {
                 .addModifiers(Modifier.PRIVATE, Modifier.STATIC)
                 .superclass(ParameterizedTypeName.get(mutableCollectionType, typeArguments))
                 .addTypeVariables(Arrays.asList(typeVariables))
+                .addField(FieldSpec
+                        .builder(TypeName.LONG, "serialVersionUID", Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
+                        .addAnnotation(Serial.class).initializer("1L").build())
                 .addMethod(MethodSpec.constructorBuilder().addAnnotation(generatedRecordBuilderAnnotation)
                         .addStatement("super()").build())
                 .addMethod(MethodSpec.constructorBuilder().addAnnotation(generatedRecordBuilderAnnotation)

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/RecordBuilderProcessor.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/RecordBuilderProcessor.java
@@ -45,6 +45,8 @@ public class RecordBuilderProcessor extends AbstractProcessor {
 
     static final AnnotationSpec generatedRecordBuilderAnnotation = AnnotationSpec.builder(Generated.class)
             .addMember("value", "$S", RecordBuilder.class.getName()).build();
+    static final AnnotationSpec suppressWarningsAnnotation = AnnotationSpec.builder(SuppressWarnings.class)
+            .addMember("value", "$S", "unchecked").build();
     static final AnnotationSpec generatedRecordInterfaceAnnotation = AnnotationSpec.builder(Generated.class)
             .addMember("value", "$S", RecordInterface.class.getName()).build();
     static final AnnotationSpec recordBuilderGeneratedAnnotation = AnnotationSpec.builder(RecordBuilderGenerated.class)


### PR DESCRIPTION
This PR fixes the `serial` and `unchecked` warnings in the generated builder classes by adding `@SuppressWarnings("unchecked")` to the `__<collection>` functions and by adding `public static final long serialVersionUID = 1L;` to the subclassed collections.