### PR TITLE
Alternate staged builders that handle optional, etc.

### DIFF
--- a/options.md
+++ b/options.md
@@ -74,6 +74,12 @@ Use `@RecordBuilder.Options(builderMode = BuilderMode.STAGED)` or `@RecordBuilde
 builders. Staged builders require that each record component is built in order and that each component is specified. The generated builder ensures
 this via individual staged builders. See [TestStagedBuilder](record-builder-test/src/test/java/io/soabase/recordbuilder/test/staged/TestStagedBuilder.java) for examples.
 
+A variant of staged builders is available that only stages required record components. Use `BuilderMode.STAGED_REQUIRED_ONLY` or `BuilderMode.STANDARD_AND_STAGED_REQUIRED_ONLY`. 
+The following are not staged and are added to the final stage:
+- optional components (when `addConcreteSettersForOptional` is enabled)  
+- Any collections matching enabled [Collection options](#collections)  
+- Any annotated compontents that match the `nullablePattern()` pattern option (e.g. `@Nullable`)
+
 ## Default Values / Initializers
 
 | option                                                             | details                                                                                                                          |
@@ -88,11 +94,12 @@ for an example.
 
 ## Null Handling
 
-| option                                                          | details                                                                                                       |
-|-----------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------|
-| `@RecordBuilder.Options(interpretNotNulls = true/false)`        | Add not-null checks for record components annotated with any null-pattern annotation. The default is `false`. |
-| `@RecordBuilder.Options(interpretNotNullsPattern = "regex")`    | The regex pattern used to determine if an annotation name means non-null.                                     |
-| `@RecordBuilder.Options(allowNullableCollections = true/false)` | Adds special null handling for record collectioncomponents. The default is `false`.                           |
+| option                                                          | details                                                                                                          |
+|-----------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------|
+| `@RecordBuilder.Options(interpretNotNulls = true/false)`        | Add not-null checks for record components annotated with any null-pattern annotation. The default is `false`.    |
+| `@RecordBuilder.Options(interpretNotNullsPattern = "regex")`    | The regex pattern used to determine if an annotation name means non-null.                                        |
+| `@RecordBuilder.Options(allowNullableCollections = true/false)` | Adds special null handling for record collectioncomponents. The default is `false`.                              |
+| `@RecordBuilder.Options(nullablePattern = "regex")`             | Regex pattern to use for `BuilderMode.STAGED_REQUIRED_ONLY` and `BuilderMode.STANDARD_AND_STAGED_REQUIRED_ONLY`. |
 
 ## Collections
 

--- a/record-builder-core/src/main/java/io/soabase/recordbuilder/core/RecordBuilder.java
+++ b/record-builder-core/src/main/java/io/soabase/recordbuilder/core/RecordBuilder.java
@@ -323,6 +323,12 @@ public @interface RecordBuilder {
         String stagedBuilderMethodSuffix() default "Stage";
 
         /**
+         * If {@link #builderMode()} is `STAGED_REQUIRED_ONLY` or `STANDARD_AND_STAGED_REQUIRED_ONLY, this is the regex
+         * pattern used to determine if an annotation name means "null-able"
+         */
+        String nullablePattern() default "(?i)^((null)|(nullable))$";
+
+        /**
          * If true, attributes can be set/assigned only 1 time. Attempts to reassign/reset attributes will throw
          * {@code java.lang.IllegalStateException}
          */
@@ -345,7 +351,7 @@ public @interface RecordBuilder {
     }
 
     enum BuilderMode {
-        STANDARD, STAGED, STANDARD_AND_STAGED,
+        STANDARD, STAGED, STAGED_REQUIRED_ONLY, STANDARD_AND_STAGED, STANDARD_AND_STAGED_REQUIRED_ONLY,
     }
 
     /**

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/staged/OptionalListStaged.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/staged/OptionalListStaged.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 The original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.soabase.recordbuilder.test.staged;
+
+import io.soabase.recordbuilder.core.RecordBuilder;
+
+import javax.validation.constraints.Null;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+@RecordBuilder
+@RecordBuilder.Options(builderMode = RecordBuilder.BuilderMode.STAGED_REQUIRED_ONLY, interpretNotNulls = true, useImmutableCollections = true)
+public record OptionalListStaged(int a, Optional<String> b, double c, List<Instant> d, @Null String e, String f) {
+}

--- a/record-builder-test/src/test/java/io/soabase/recordbuilder/test/staged/TestStagedBuilder.java
+++ b/record-builder-test/src/test/java/io/soabase/recordbuilder/test/staged/TestStagedBuilder.java
@@ -20,6 +20,8 @@ import org.junit.jupiter.api.Test;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -72,5 +74,15 @@ public class TestStagedBuilder {
     void testNoFields() {
         NoFieldsStaged obj = NoFieldsStagedBuilder.builder().build();
         assertEquals(new NoFieldsStaged(), obj);
+    }
+
+    @Test
+    void testOptionalList() {
+        OptionalListStaged obj = OptionalListStagedBuilder.builder().a(1).c(1.1).f("ffff").b(Optional.of("bbbb"))
+                .d(List.of(Instant.EPOCH)).e("eeee").build();
+        assertEquals(new OptionalListStaged(1, Optional.of("bbbb"), 1.1, List.of(Instant.EPOCH), "eeee", "ffff"), obj);
+
+        obj = OptionalListStagedBuilder.builder().a(1).c(1.1).f("ffff").build();
+        assertEquals(new OptionalListStaged(1, Optional.empty(), 1.1, List.of(), null, "ffff"), obj);
     }
 }


### PR DESCRIPTION
A variant of staged builders is available that only stages required record components. Any optional components (when `addConcreteSettersForOptional` is enabled) are not staged and are added to the final stage. Additionally, if Collection options are enabled, those too are added to the final stage.

Closes #170

attn: @olsavmic 

Reviewers - please test various use cases. I'm not very familiar with this feature and did what I thought was right.