### PR TITLE
Add annotationProcessorPaths to the pom.xml code snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,15 +327,35 @@ annotation. Use `packagePattern` to change this (see Javadoc for details).
 
 ### Maven
 
-Add a dependency that contains the discoverable annotation processor:
+Add the `record-builder-core` dependency and specify the annotation processor in the Maven Compiler Plugin:
 
 ```xml
-<dependency>
-    <groupId>io.soabase.record-builder</groupId>
-    <artifactId>record-builder-processor</artifactId>
-    <version>${record.builder.version}</version>
-    <scope>provided</scope>
-</dependency>
+<dependencies>
+    <dependency>
+        <groupId>io.soabase.record-builder</groupId>
+        <artifactId>record-builder-core</artifactId>
+        <version>${record.builder.version}</version>
+        <scope>provided</scope>
+    </dependency>
+</dependencies>
+
+<build>
+    <plugins>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+                <annotationProcessorPaths>
+                    <path>
+                        <groupId>io.soabase.record-builder</groupId>
+                        <artifactId>record-builder-processor</artifactId>
+                        <version>${record.builder.version}</version>
+                    </path>
+                </annotationProcessorPaths>
+            </configuration>
+        </plugin>
+    </plugins>
+</build>
 ```
 
 ### Gradle


### PR DESCRIPTION
As of JDK23, javac doesn't automatically detect discoverable annotation processors by default.
In this PR, I add the explicit definition of the processor annotation in the maven-compiler-plugin.
I hope this will make it easier for future users to add RecordBuilder to their project.

Sources:

- [Changes Default Annotation Processing Policy](https://inside.java/2024/06/18/quality-heads-up/#jdk-23-changes-default-annotation-processing-policy)

**Edit**
Worth to add: for Gradle, the annotation processor is already explicitly defined via `annotationProcessor`, so there is no problem with JDK23.