### PR TITLE
Filter out jakarta @Valid annotations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
         <asm-version>7.2</asm-version>
         <validation-api-version>2.0.1.Final</validation-api-version>
         <hibernate-validator-version>6.2.0.Final</hibernate-validator-version>
+        <jakarta-validation-api-version>3.1.0</jakarta-validation-api-version>
         <javax-el-version>3.0.1-b09</javax-el-version>
     </properties>
 
@@ -162,6 +163,12 @@
                 <groupId>javax.validation</groupId>
                 <artifactId>validation-api</artifactId>
                 <version>${validation-api-version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>jakarta.validation</groupId>
+                <artifactId>jakarta.validation-api</artifactId>
+                <version>${jakarta-validation-api-version}</version>
             </dependency>
 
             <dependency>

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/InternalRecordBuilderProcessor.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/InternalRecordBuilderProcessor.java
@@ -53,7 +53,8 @@ class InternalRecordBuilderProcessor {
 
     private static final TypeName optionalType = TypeName.get(Optional.class);
     private static final TypeName overrideType = TypeName.get(Override.class);
-    private static final TypeName validType = ClassName.get("javax.validation", "Valid");
+    private static final TypeName javaxValidType = ClassName.get("javax.validation", "Valid");
+    private static final TypeName jakartaValidType = ClassName.get("jakarta.validation", "Valid");
     private static final TypeName validatorTypeName = ClassName.get("io.soabase.recordbuilder.validator",
             "RecordBuilderValidator");
     private static final TypeVariableName rType = TypeVariableName.get("R");
@@ -868,7 +869,7 @@ class InternalRecordBuilderProcessor {
     }
 
     private boolean filterOutValid(AnnotationSpec annotationSpec) {
-        return !annotationSpec.type.equals(validType);
+        return !annotationSpec.type.equals(javaxValidType) && !annotationSpec.type.equals(jakartaValidType);
     }
 
     private void addConstructorAnnotations(RecordClassType component, ParameterSpec.Builder parameterSpecBuilder) {

--- a/record-builder-test/pom.xml
+++ b/record-builder-test/pom.xml
@@ -37,6 +37,11 @@
         </dependency>
 
         <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.soabase.record-builder</groupId>
             <artifactId>record-builder-processor</artifactId>
             <scope>provided</scope>

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/RequestWithValid.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/RequestWithValid.java
@@ -23,7 +23,8 @@ import javax.validation.constraints.NotNull;
 
 @RecordBuilder
 @RecordBuilder.Options(useValidationApi = true)
-public record RequestWithValid(@NotNull @Valid Part part) implements RequestWithValidBuilder.With {
+public record RequestWithValid(@NotNull @Valid @jakarta.validation.Valid Part part)
+        implements RequestWithValidBuilder.With {
     public record Part(@NotBlank String name) {
     }
 }

--- a/record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestAnnotated.java
+++ b/record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestAnnotated.java
@@ -18,6 +18,7 @@ package io.soabase.recordbuilder.test;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import javax.validation.Valid;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
@@ -29,6 +30,18 @@ class TestAnnotated {
     void testInheritComponentAnnotationsFalse() throws NoSuchMethodException {
         var method = IgnoreAnnotatedBuilder.class.getMethod("s");
         Assertions.assertNull(method.getAnnotation(NotNull.class));
+    }
+
+    @Test
+    void testFiltersOutJavaXValid() throws NoSuchMethodException {
+        var method = RequestWithValidBuilder.With.class.getMethod("part");
+        Assertions.assertNull(method.getAnnotation(Valid.class));
+    }
+
+    @Test
+    void testFiltersOutJakartaValid() throws NoSuchMethodException {
+        var method = RequestWithValidBuilder.With.class.getMethod("part");
+        Assertions.assertNull(method.getAnnotation(jakarta.validation.Valid.class));
     }
 
     @Test


### PR DESCRIPTION
This modifies the record processor to filter out `@Valid` annotations from both javax/jakarta, which fixes https://github.com/Randgalt/record-builder/issues/189. I also added tests for both.

Note: this doesn't add support for validation using Jakarta, since that would require bumping the Hibernator version and changes to the validator/additional validators to preserve support for both validation APIs.