### PR TITLE
Consider initializers for staged required only builders

### DIFF
--- a/options.md
+++ b/options.md
@@ -78,13 +78,15 @@ A variant of staged builders is available that only stages required record compo
 The following are not staged and are added to the final stage:
 - optional components (when `addConcreteSettersForOptional` is enabled)  
 - Any collections matching enabled [Collection options](#collections)  
-- Any annotated compontents that match the `nullablePattern()` pattern option (e.g. `@Nullable`)
+- Any annotated components that match the `nullablePattern()` pattern option (e.g. `@Nullable`)
+- Any components with initializers (annotated with `@RecordBuilder.Initializer(...)`) when `skipStagingForInitializedComponents` is enabled
 
 ## Default Values / Initializers
 
-| option                                                             | details                                                                                                                          |
-|--------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------|
-| `@RecordBuilder.Options(emptyDefaultForOptional = true/false)` | Set the default value of `Optional` record components to `Optional.empty()`. The default is `true`.           |
+| option                                                                     | details                                                                                                                                                                                                                                          |
+|----------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `@RecordBuilder.Options(emptyDefaultForOptional = true/false)`             | Set the default value of `Optional` record components to `Optional.empty()`. The default is `true`.                                                                                                                                              |
+| `@RecordBuilder.Options(skipStagingForInitializedComponents = true/false)` | If true, components with initializers (`@RecordBuilder.Initializer`) are excluded from staging when `builderMode` is `STAGED_REQUIRED_ONLY` or `STANDARD_AND_STAGED_REQUIRED_ONLY` and are only included in the final stage. Default is `false`. |
 
 ### `@RecordBuilder.Initializer`
 

--- a/record-builder-core/src/main/java/io/soabase/recordbuilder/core/RecordBuilder.java
+++ b/record-builder-core/src/main/java/io/soabase/recordbuilder/core/RecordBuilder.java
@@ -329,6 +329,13 @@ public @interface RecordBuilder {
         String nullablePattern() default "(?i)^((null)|(nullable))$";
 
         /**
+         * If true, components with initializers (annotated with {@link RecordBuilder.Initializer}) are excluded from
+         * staging when {@link #builderMode()} is `STAGED_REQUIRED_ONLY` or `STANDARD_AND_STAGED_REQUIRED_ONLY` and are
+         * only included in the final stage. Default is false, meaning initialized components are considered required.
+         */
+        boolean skipStagingForInitializedComponents() default false;
+
+        /**
          * If true, attributes can be set/assigned only 1 time. Attempts to reassign/reset attributes will throw
          * {@code java.lang.IllegalStateException}
          */

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/InternalRecordBuilderProcessor.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/InternalRecordBuilderProcessor.java
@@ -216,7 +216,7 @@ class InternalRecordBuilderProcessor {
             return false;
         }
 
-        if (metaData.skipStagingForInitializedComponents() && initializers.get(recordComponent.name()) != null) {
+        if (metaData.skipStagingForInitializedComponents() && initializers.containsKey(recordComponent.name())) {
             return false;
         }
 

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/InternalRecordBuilderProcessor.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/InternalRecordBuilderProcessor.java
@@ -216,6 +216,10 @@ class InternalRecordBuilderProcessor {
             return false;
         }
 
+        if (metaData.skipStagingForInitializedComponents() && initializers.get(recordComponent.name()) != null) {
+            return false;
+        }
+
         return !metaData.emptyDefaultForOptional() || !recordComponent.rawTypeName().equals(optionalType);
     }
 

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/staged/InitializedStaged.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/staged/InitializedStaged.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 The original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.soabase.recordbuilder.test.staged;
+
+import io.soabase.recordbuilder.core.RecordBuilder;
+
+@RecordBuilder
+@RecordBuilder.Options(builderMode = RecordBuilder.BuilderMode.STAGED_REQUIRED_ONLY, skipStagingForInitializedComponents = true)
+public record InitializedStaged(@RecordBuilder.Initializer("defaultAge") int age, String name) {
+
+    public static int defaultAge() {
+        return 18;
+    }
+}

--- a/record-builder-test/src/test/java/io/soabase/recordbuilder/test/staged/TestStagedBuilder.java
+++ b/record-builder-test/src/test/java/io/soabase/recordbuilder/test/staged/TestStagedBuilder.java
@@ -85,4 +85,10 @@ public class TestStagedBuilder {
         obj = OptionalListStagedBuilder.builder().a(1).c(1.1).f("ffff").build();
         assertEquals(new OptionalListStaged(1, Optional.empty(), 1.1, List.of(), null, "ffff"), obj);
     }
+
+    @Test
+    void testInitialized() {
+        InitializedStaged obj = InitializedStagedBuilder.builder().name("foo").age(42).build();
+        assertEquals(new InitializedStaged(42, "foo"), obj);
+    }
 }


### PR DESCRIPTION
### Background

Fixes #187

### Changes

Components with initializers (annotated with `@RecordBuilder.Initializer(...)`) are now excluded from staging in "staged required only" builders and are added to the final stage.

A new option `skipStagingForInitializedComponents` controls this behavior. 
By default, initialized components are still considered required and staged.

### Discussion Points

- [x] This is a breaking change to "staged required only" builders. Is this acceptable or would this need to be a behavior toggled through a new option? - **Added option to control this behavior**

- [ ] This is my first contribution to this project and the first time taking a look at the codebase. Is this minimal change correctly done or did I miss some edge cases?