### PR TITLE
Fix warning about unrecognized processor options

### DIFF
--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/RecordBuilderOptions.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/RecordBuilderOptions.java
@@ -20,6 +20,9 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 class RecordBuilderOptions {
     private static final Map<String, Object> defaultValues = buildDefaultValues();
@@ -50,6 +53,11 @@ class RecordBuilderOptions {
                     }
                     return defaultValue;
                 });
+    }
+
+    static Set<String> optionNames() {
+        return Stream.of(RecordBuilder.Options.class.getDeclaredMethods()).map(Method::getName)
+                .collect(Collectors.toUnmodifiableSet());
     }
 
     private static Map<String, Object> buildDefaultValues() {

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/RecordBuilderProcessor.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/RecordBuilderProcessor.java
@@ -60,6 +60,11 @@ public class RecordBuilderProcessor extends AbstractProcessor {
     }
 
     @Override
+    public Set<String> getSupportedOptions() {
+        return RecordBuilderOptions.optionNames();
+    }
+
+    @Override
     public Set<String> getSupportedAnnotationTypes() {
         return Set.of("*");
     }


### PR DESCRIPTION
On compile we otherwise get the warning "The following options were not recognized by any processor" which might trick users into thinking that their options were not accepted by the RecordBuilder annotation processor.

Fixes #198