### PR TITLE
[Fixes #200] Fix for the issue with addFunctionalMethodsToWith and getter/boolean prefix settings not playing nice with each other.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 # Default ignored files
 .idea
+.classpath
+.project
+.settings/
 **/target/**
-

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/InternalRecordBuilderProcessor.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/InternalRecordBuilderProcessor.java
@@ -378,7 +378,7 @@ class InternalRecordBuilderProcessor {
          */
         var codeBlockBuilder = CodeBlock.builder().add("return new $L$L(", builderClassType.name(),
                 typeVariables.isEmpty() ? "" : "<>");
-        addComponentCallsAsArguments(-1, codeBlockBuilder, false);
+        addComponentCallsAsArguments(-1, codeBlockBuilder);
         codeBlockBuilder.add(");");
         var methodSpec = MethodSpec.methodBuilder(metaData.withClassMethodPrefix())
                 .addAnnotation(generatedRecordBuilderAnnotation)
@@ -411,7 +411,7 @@ class InternalRecordBuilderProcessor {
             codeBlockBuilder.add("$T.validate(", validatorTypeName);
         }
         codeBlockBuilder.add("new $T(", recordClassType.typeName());
-        addComponentCallsAsArguments(index, codeBlockBuilder, false);
+        addComponentCallsAsArguments(index, codeBlockBuilder);
         codeBlockBuilder.add(")");
         if (metaData.useValidationApi()) {
             codeBlockBuilder.add(")");
@@ -446,7 +446,7 @@ class InternalRecordBuilderProcessor {
         classBuilder.addMethod(methodSpec);
     }
 
-    private void addComponentCallsAsArguments(int index, CodeBlock.Builder codeBlockBuilder, boolean usePrefixedName) {
+    private void addComponentCallsAsArguments(int index, CodeBlock.Builder codeBlockBuilder) {
         IntStream.range(0, recordComponents.size()).forEach(parameterIndex -> {
             if (parameterIndex > 0) {
                 codeBlockBuilder.add(", ");
@@ -455,8 +455,7 @@ class InternalRecordBuilderProcessor {
             if (parameterIndex == index) {
                 collectionBuilderUtils.addShimCall(codeBlockBuilder, parameterComponent);
             } else {
-                codeBlockBuilder.add("$L()",
-                        usePrefixedName ? prefixedName(parameterComponent, true) : parameterComponent.name());
+                codeBlockBuilder.add("$L()", parameterComponent.name());
             }
         });
     }
@@ -1118,7 +1117,7 @@ class InternalRecordBuilderProcessor {
             methodBuilder.addJavadoc("Perform an operation on record components");
         }
         codeBlockBuilder.add("proc.apply(");
-        addComponentCallsAsArguments(-1, codeBlockBuilder, false);
+        addComponentCallsAsArguments(-1, codeBlockBuilder);
         codeBlockBuilder.add(");");
         methodBuilder.addCode(codeBlockBuilder.build());
         return methodBuilder.build();

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/InternalRecordBuilderProcessor.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/InternalRecordBuilderProcessor.java
@@ -1118,7 +1118,7 @@ class InternalRecordBuilderProcessor {
             methodBuilder.addJavadoc("Perform an operation on record components");
         }
         codeBlockBuilder.add("proc.apply(");
-        addComponentCallsAsArguments(-1, codeBlockBuilder, true);
+        addComponentCallsAsArguments(-1, codeBlockBuilder, false);
         codeBlockBuilder.add(");");
         methodBuilder.addCode(codeBlockBuilder.build());
         return methodBuilder.build();

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/CustomMethodNamesWithFunctionalMethods.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/CustomMethodNamesWithFunctionalMethods.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 The original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.soabase.recordbuilder.test;
+
+import java.util.List;
+import java.util.Map;
+
+import io.soabase.recordbuilder.core.RecordBuilder;
+
+@RecordBuilder
+@RecordBuilder.Options(getterPrefix = "get", booleanPrefix = "is", addFunctionalMethodsToWith = true)
+public record CustomMethodNamesWithFunctionalMethods<K, V>(Map<K, V> kvMap, int theValue, List<Integer> theList,
+        boolean theBoolean) implements CustomMethodNamesWithFunctionalMethodsBuilder.With {
+}


### PR DESCRIPTION
This is, I believe, the minimal change needed to fix issue#200 (other than the .gitignore changes of course).

That said, while poking around after making my change I noticed that the `boolean` argument to the `addComponentCallsAsArguments` method is now _always_ set to `false`. Assuming there are no objections to this change I could also update this PR to remove that parameter if desired. From what my IDE tells me there are only three places where this method is used so this additional change would also be quite small.