### PR TITLE
Where possible, use Builders for generated deconstructors

### DIFF
--- a/deconstructors.md
+++ b/deconstructors.md
@@ -57,8 +57,9 @@ RecordBuilder will generate a `record` (and record builder) similar to:
 ```java
 public record MyClassDao(int qty, String name) {
     public static MyClassDao from(MyClass rhs) {
-        ... components = rhs.deconstructor(...);
-        return new MyClassDao(... components ...);
+        MyClassDaoBuilder builder = MyClassDaoBuilder.builder();
+        rhs.deconstructor(builder::qty, builder::name);
+        return builder.build();
     }
 }
 ```

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/InternalRecordBuilderProcessor.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/InternalRecordBuilderProcessor.java
@@ -21,6 +21,7 @@ import io.soabase.recordbuilder.core.RecordBuilder.BuilderMode;
 import io.soabase.recordbuilder.processor.CollectionBuilderUtils.SingleItemsMetaData;
 
 import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.Element;
 import javax.lang.model.element.Modifier;
 import java.util.*;
 import java.util.function.BiConsumer;
@@ -85,7 +86,7 @@ class InternalRecordBuilderProcessor {
             builder.addAnnotation(recordBuilderGeneratedAnnotation);
         }
 
-        if (!validateMethodNameConflicts(processingEnv)) {
+        if (!validateMethodNameConflicts(processingEnv, recordFacade.element())) {
             builderType = Optional.empty();
             return;
         }
@@ -156,10 +157,11 @@ class InternalRecordBuilderProcessor {
         return builderType;
     }
 
-    private boolean validateMethodNameConflicts(ProcessingEnvironment processingEnv) {
+    private boolean validateMethodNameConflicts(ProcessingEnvironment processingEnv, Element element) {
         BiConsumer<String, String> reportError = (name, option) -> processingEnv.getMessager().printMessage(ERROR,
                 "Record component \"%s\" conflicts with RecordBuilder option \"%s\". Change the value of the option."
-                        .formatted(name, option));
+                        .formatted(name, option),
+                element);
 
         return recordComponents.stream().allMatch(recordComponent -> {
             if (recordComponent.name().equals(metaData.builderMethodName())) {

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/RecordBuilderProcessor.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/RecordBuilderProcessor.java
@@ -226,7 +226,7 @@ public class RecordBuilderProcessor extends AbstractProcessor {
             ClassType builderClassType = ElementUtils.getClassType(deconstructorProcessor.packageName(),
                     generateName(typeElement, deconstructorProcessor.recordClassType(), metaData.suffix(),
                             metaData.prefixEnclosingClassNames()),
-                    (typeElement).getTypeParameters());
+                    typeElement.getTypeParameters());
             Map<String, CodeBlock> initializers = InitializerUtil.detectInitializers(processingEnv, typeElement);
             RecordFacade recordFacade = new RecordFacade(executableElement, deconstructorProcessor.packageName(),
                     deconstructorProcessor.recordClassType(), builderClassType, deconstructorProcessor.typeVariables(),

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/RecordBuilderProcessor.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/RecordBuilderProcessor.java
@@ -228,7 +228,7 @@ public class RecordBuilderProcessor extends AbstractProcessor {
                             metaData.prefixEnclosingClassNames()),
                     (typeElement).getTypeParameters());
             Map<String, CodeBlock> initializers = InitializerUtil.detectInitializers(processingEnv, typeElement);
-            RecordFacade recordFacade = new RecordFacade(deconstructorProcessor.packageName(),
+            RecordFacade recordFacade = new RecordFacade(executableElement, deconstructorProcessor.packageName(),
                     deconstructorProcessor.recordClassType(), builderClassType, deconstructorProcessor.typeVariables(),
                     deconstructorProcessor.recordComponents(), initializers, typeElement.getModifiers(), true);
 

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/RecordFacade.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/RecordFacade.java
@@ -30,7 +30,7 @@ import java.util.stream.IntStream;
 
 import static io.soabase.recordbuilder.processor.ElementUtils.generateName;
 
-record RecordFacade(String packageName, ClassType recordClassType, ClassType builderClassType,
+record RecordFacade(Element element, String packageName, ClassType recordClassType, ClassType builderClassType,
         List<TypeVariableName> typeVariables, List<RecordClassType> recordComponents,
         Map<String, CodeBlock> initializers, Set<Modifier> modifiers, boolean builderIsInRecordPackage) {
     public static RecordFacade fromTypeElement(ProcessingEnvironment processingEnv, TypeElement record,
@@ -46,7 +46,7 @@ record RecordFacade(String packageName, ClassType recordClassType, ClassType bui
         List<RecordClassType> recordComponents = buildRecordComponents(processingEnv, record);
         Map<String, CodeBlock> initializers = InitializerUtil.detectInitializers(processingEnv, record);
 
-        return new RecordFacade(packageName, recordClassType, builderClassType, typeVariables, recordComponents,
+        return new RecordFacade(record, packageName, recordClassType, builderClassType, typeVariables, recordComponents,
                 initializers, record.getModifiers(), recordActualPackage.equals(packageName));
     }
 

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/deconstructors/ClassWithStaged.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/deconstructors/ClassWithStaged.java
@@ -16,21 +16,14 @@
 package io.soabase.recordbuilder.test.deconstructors;
 
 import io.soabase.recordbuilder.core.RecordBuilder;
-import io.soabase.recordbuilder.core.RecordBuilder.Deconstructor;
 
-import java.util.List;
-import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.IntConsumer;
 
-public class UniqueVarNameCheck {
-    @Deconstructor
-    @RecordBuilder.Options(builderMode = RecordBuilder.BuilderMode.STAGED) // use staged so that deconstructor can't use
-                                                                           // builder
-    public void unapply(Consumer<Map<String, List<Double>>> components, IntConsumer rhs) {
-    }
-
-    @Deconstructor(suffix = "Alt")
-    public void unapplyWithBuilder(Consumer<Map<String, List<Double>>> c, IntConsumer rhs) {
+public class ClassWithStaged {
+    @RecordBuilder.Deconstructor
+    @RecordBuilder.Options(builderMode = RecordBuilder.BuilderMode.STAGED)
+    public void deconstructor(IntConsumer i, Consumer<String> s) {
+        // notning
     }
 }

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/deconstructors/UniqueVarNameCheck2.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/deconstructors/UniqueVarNameCheck2.java
@@ -23,14 +23,13 @@ import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.IntConsumer;
 
-public class UniqueVarNameCheck {
+public class UniqueVarNameCheck2 {
     @Deconstructor
-    @RecordBuilder.Options(builderMode = RecordBuilder.BuilderMode.STAGED) // use staged so that deconstructor can't use
-                                                                           // builder
     public void unapply(Consumer<Map<String, List<Double>>> components, IntConsumer rhs) {
     }
 
     @Deconstructor(suffix = "Alt")
-    public void unapplyWithBuilder(Consumer<Map<String, List<Double>>> c, IntConsumer rhs) {
+    @RecordBuilder.Options(builderMethodName = "altBuilder")
+    public void unapplyWithBuilder(Consumer<Map<String, List<Double>>> builder, IntConsumer rhs) {
     }
 }


### PR DESCRIPTION
This ensures all options are applied (nullability, etc.). Also, it simply makes more sense.
