### PR TITLE
Fixed #218 - Simplifying maven plugin configurations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,8 @@
         <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <jdk-version>17</jdk-version>
+        <maven.compiler.release>17</maven.compiler.release>
+        <automatic-module-name>io.soabase.recordbuilder</automatic-module-name>
 
         <maven-compiler-plugin-version>3.14.0</maven-compiler-plugin-version>
         <maven-source-plugin-version>3.2.0</maven-source-plugin-version>
@@ -186,7 +187,6 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${maven-compiler-plugin-version}</version>
                     <configuration>
-                        <release>${jdk-version}</release>
                         <compilerArgs>
                             <arg>-Xlint:all</arg>
                         </compilerArgs>
@@ -197,9 +197,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-install-plugin</artifactId>
                     <version>${maven-install-plugin-version}</version>
-                    <configuration>
-                        <createChecksum>true</createChecksum>
-                    </configuration>
                 </plugin>
 
                 <plugin>
@@ -210,7 +207,7 @@
                         <execution>
                             <id>attach-sources</id>
                             <goals>
-                                <goal>jar</goal>
+                                <goal>jar-no-fork</goal>
                             </goals>
                         </execution>
                     </executions>
@@ -333,6 +330,13 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>${maven-jar-plugin-version}</version>
+                    <configuration>
+                        <archive>
+                            <manifestEntries>
+                                <Automatic-Module-Name>${automatic-module-name}</Automatic-Module-Name>
+                            </manifestEntries>
+                        </archive>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/record-builder-core/pom.xml
+++ b/record-builder-core/pom.xml
@@ -28,21 +28,7 @@
 
     <properties>
         <license-file-path>${project.parent.basedir}/src/etc/header.txt</license-file-path>
+        <automatic-module-name>io.soabase.recordbuilder.core</automatic-module-name>
     </properties>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <archive>
-                        <manifestEntries>
-                            <Automatic-Module-Name>io.soabase.recordbuilder.core</Automatic-Module-Name>
-                        </manifestEntries>
-                    </archive>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/record-builder-processor/pom.xml
+++ b/record-builder-processor/pom.xml
@@ -28,6 +28,7 @@
 
     <properties>
         <license-file-path>${project.parent.basedir}/src/etc/header.txt</license-file-path>
+        <maven.compiler.proc>none</maven.compiler.proc>
     </properties>
 
     <dependencies>
@@ -41,16 +42,4 @@
             <artifactId>record-builder-core</artifactId>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <proc>none</proc>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/record-builder-test/pom.xml
+++ b/record-builder-test/pom.xml
@@ -28,6 +28,8 @@
 
     <properties>
         <license-file-path>${project.parent.basedir}/src/etc/header.txt</license-file-path>
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <maven.install.skip>true</maven.install.skip>
     </properties>
 
     <dependencies>
@@ -79,22 +81,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-install-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>

--- a/record-builder-validator/pom.xml
+++ b/record-builder-validator/pom.xml
@@ -28,21 +28,7 @@
 
     <properties>
         <license-file-path>${project.parent.basedir}/src/etc/header.txt</license-file-path>
+        <automatic-module-name>io.soabase.recordbuilder.validator</automatic-module-name>
     </properties>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <archive>
-                        <manifestEntries>
-                            <Automatic-Module-Name>io.soabase.recordbuilder.validator</Automatic-Module-Name>
-                        </manifestEntries>
-                    </archive>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>


### PR DESCRIPTION
- maven-jar-plugin
  - defining automatic module name in root; and define default value. override it in required sub-projects.
- maven-compiler-plugin
  - Using maven.compiler.release instead custom property.
  - Using maven.compiler.proc instead.
- maven-sources-plugin
  - using jar-no-fork goal instead of jar to prevent life cycle forking.
- maven-install-plugin/maven-deploy-plugin
  - using maven.deploy.skip, maven.install.skip property.