### PR TITLE
Add support to configure adding jackson @JsonPOJOBuilder annotations to generated builders

### DIFF
--- a/options.md
+++ b/options.md
@@ -54,6 +54,12 @@ The names used for generated methods, classes, etc. can be changed via the follo
 | `@RecordBuilder.Options(fileIndent = "    ")`                    | Return the file indent to use.                                                                                                                           |
 | `@RecordBuilder.Options(prefixEnclosingClassNames = true/false)` | If the record is declared inside another class, the outer class's name will be prefixed to the builder name if this returns true. The default is `true`. |
 
+## Jackson Support
+
+| option                                                       | details                                                                                                                                                                                                                                                                                                                      |
+|--------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `@RecordBuilder.Options(addJacksonAnnotations = true/false)` | If true, builders will be annotated with `@JsonPOJOBuilder` Jackson annotations which can be used in combination with `@JsonDeserialize(builder = ...)`. See [TestJacksonAnnotations](./record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestJacksonAnnotations.java) for an example. The default is `false`. |
+
 ## Miscellaneous
 
 | option                                                                     | details                                                                                                                                                          |

--- a/options.md
+++ b/options.md
@@ -54,12 +54,6 @@ The names used for generated methods, classes, etc. can be changed via the follo
 | `@RecordBuilder.Options(fileIndent = "    ")`                    | Return the file indent to use.                                                                                                                           |
 | `@RecordBuilder.Options(prefixEnclosingClassNames = true/false)` | If the record is declared inside another class, the outer class's name will be prefixed to the builder name if this returns true. The default is `true`. |
 
-## Jackson Support
-
-| option                                                       | details                                                                                                                                                                                                                                                                                                                      |
-|--------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `@RecordBuilder.Options(addJacksonAnnotations = true/false)` | If true, builders will be annotated with `@JsonPOJOBuilder` Jackson annotations which can be used in combination with `@JsonDeserialize(builder = ...)`. See [TestJacksonAnnotations](./record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestJacksonAnnotations.java) for an example. The default is `false`. |
-
 ## Miscellaneous
 
 | option                                                                     | details                                                                                                                                                          |
@@ -122,3 +116,58 @@ Special handling for collections. See the project test classes for usage.
 | `@RecordBuilder.Options(useUnmodifiableCollections = true/false)`      | Adds special handling for collection record components. The default is `false`.     |
 | `@RecordBuilder.Options(allowNullableCollections = true/false)`        | Adds special null handling for record collectioncomponents. The default is `false`. |
 | `@RecordBuilder.Options(addSingleItemCollectionBuilders = true/false)` | Adds special handling for record collectioncomponents. The default is `false`.      |
+
+## Jackson Support
+
+RecordBuilder can automatically add Jackson annotations to generated builders, supporting both Jackson 2.x and 3.x. Configuration is done via the nested `@JacksonConfig` annotation.
+
+### Basic Example
+
+```java
+@RecordBuilder
+@RecordBuilder.Options(
+    jackson = @RecordBuilder.JacksonConfig(jsonPOJOBuilder = true)
+)
+@JsonDeserialize(builder = UserRecordBuilder.class)
+record UserRecord(String name, int age) {}
+```
+
+### Configuration Options
+
+| option | details |
+|--------|---------|
+| `jackson = @JacksonConfig(...)` | Configures Jackson annotation support for the generated builder. By default, no Jackson annotations are added. |
+
+### JacksonConfig Properties
+
+| property | details |
+|----------|---------|
+| `jsonPOJOBuilder` | **boolean** (default: `false`) - When `true`, adds `@JsonPOJOBuilder` annotation to the generated builder. This annotation works with `@JsonDeserialize(builder = ...)` on the record. |
+| `version` | **JacksonVersion** (default: `AUTO`) - Specifies which Jackson version to use:<br/>• `AUTO` - Automatically detect Jackson version(s) on classpath and add all found annotations. If both Jackson 2.x and 3.x are present, annotations for both versions will be added.<br/>• `JACKSON_2` - Only add Jackson 2.x annotations (`com.fasterxml.jackson.*`). Fails if Jackson 2.x is not found.<br/>• `JACKSON_3` - Only add Jackson 3.x annotations (`tools.jackson.*`). Fails if Jackson 3.x is not found. |
+
+### Examples
+
+#### Auto-detect Jackson version (default)
+```java
+@RecordBuilder.Options(jackson = @RecordBuilder.JacksonConfig(jsonPOJOBuilder = true))
+```
+
+#### Explicit Jackson 2.x
+```java
+@RecordBuilder.Options(
+    jackson = @RecordBuilder.JacksonConfig(
+        jsonPOJOBuilder = true,
+        version = JacksonVersion.JACKSON_2
+    )
+)
+```
+
+#### With custom setter prefix
+```java
+@RecordBuilder.Options(
+    jackson = @RecordBuilder.JacksonConfig(jsonPOJOBuilder = true),
+    setterPrefix = "set"
+)
+```
+
+See [TestJacksonAnnotations](./record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestJacksonAnnotations.java) for complete examples.

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,8 @@
         <hibernate-validator-version>6.2.0.Final</hibernate-validator-version>
         <jakarta-validation-api-version>3.1.0</jakarta-validation-api-version>
         <javax-el-version>3.0.1-b09</javax-el-version>
-        <jackson-version>2.19.0</jackson-version>
+        <jackson2-version>2.21.0</jackson2-version>
+        <jackson3-version>3.0.4</jackson3-version>
         <central-publishing-maven-plugin-version>0.7.0</central-publishing-maven-plugin-version>
         <jspecify-version>1.0.0</jspecify-version>
         <lombok-version>1.18.42</lombok-version>
@@ -171,7 +172,12 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${jackson-version}</version>
+                <version>${jackson2-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>tools.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson3-version}</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
         <hibernate-validator-version>6.2.0.Final</hibernate-validator-version>
         <jakarta-validation-api-version>3.1.0</jakarta-validation-api-version>
         <javax-el-version>3.0.1-b09</javax-el-version>
+        <jackson-version>2.19.0</jackson-version>
         <central-publishing-maven-plugin-version>0.7.0</central-publishing-maven-plugin-version>
         <jspecify-version>1.0.0</jspecify-version>
         <lombok-version>1.18.42</lombok-version>
@@ -165,6 +166,12 @@
                 <groupId>org.hibernate.validator</groupId>
                 <artifactId>hibernate-validator</artifactId>
                 <version>${hibernate-validator-version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson-version}</version>
             </dependency>
 
             <dependency>

--- a/record-builder-core/src/main/java/io/soabase/recordbuilder/core/RecordBuilder.java
+++ b/record-builder-core/src/main/java/io/soabase/recordbuilder/core/RecordBuilder.java
@@ -359,6 +359,8 @@ public @interface RecordBuilder {
          * @see #nullablePattern
          */
         boolean defaultNotNull() default false;
+
+        boolean addJacksonAnnotations() default false;
     }
 
     @Retention(RetentionPolicy.CLASS)

--- a/record-builder-core/src/main/java/io/soabase/recordbuilder/core/RecordBuilder.java
+++ b/record-builder-core/src/main/java/io/soabase/recordbuilder/core/RecordBuilder.java
@@ -360,7 +360,30 @@ public @interface RecordBuilder {
          */
         boolean defaultNotNull() default false;
 
-        boolean addJacksonAnnotations() default false;
+        /**
+         * Configuration for Jackson annotation support on generated builders.
+         *
+         * @see JacksonConfig
+         */
+        JacksonConfig jackson() default @JacksonConfig;
+    }
+
+    /**
+     * Configuration for Jackson annotation support on generated builders.
+     */
+    @Retention(RetentionPolicy.CLASS)
+    @Target(ElementType.ANNOTATION_TYPE)
+    @interface JacksonConfig {
+        /**
+         * Add {@code @JsonPOJOBuilder} annotation to generated builder. This annotation works with
+         * {@code @JsonDeserialize(builder = ...)} on the record.
+         */
+        boolean jsonPOJOBuilder() default false;
+
+        /**
+         * Which Jackson version to use for annotations.
+         */
+        JacksonVersion version() default JacksonVersion.AUTO;
     }
 
     @Retention(RetentionPolicy.CLASS)
@@ -378,6 +401,29 @@ public @interface RecordBuilder {
 
     enum ConcreteSettersForOptionalMode {
         DISABLED, ENABLED, ENABLED_WITH_NULLABLE_ANNOTATION,
+    }
+
+    /**
+     * Specifies which Jackson version(s) to use when generating builder annotations.
+     */
+    enum JacksonVersion {
+        /**
+         * Automatically detect Jackson version(s) on classpath and add all found annotations. If both Jackson 2.x and
+         * 3.x are present, both annotations will be added.
+         */
+        AUTO,
+
+        /**
+         * Only add Jackson 2.x annotations (com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder). Fails if
+         * Jackson 2.x is not found on classpath.
+         */
+        JACKSON_2,
+
+        /**
+         * Only add Jackson 3.x annotations (tools.jackson.databind.annotation.JsonPOJOBuilder). Fails if Jackson 3.x is
+         * not found on classpath.
+         */
+        JACKSON_3,
     }
 
     /**

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/InternalRecordBuilderProcessor.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/InternalRecordBuilderProcessor.java
@@ -89,7 +89,7 @@ class InternalRecordBuilderProcessor {
             builder.addAnnotation(recordBuilderGeneratedAnnotation);
         }
 
-        addJacksonAnnotations();
+        new JacksonSupport(processingEnv).addJacksonAnnotations(metaData, builder);
 
         if (!validateMethodNameConflicts(processingEnv, recordFacade.element())) {
             builderType = Optional.empty();
@@ -199,18 +199,6 @@ class InternalRecordBuilderProcessor {
         } else {
             builder.addModifiers(Modifier.PUBLIC);
         }
-    }
-
-    private void addJacksonAnnotations() {
-        if (!metaData.addJacksonAnnotations()) {
-            return;
-        }
-
-        final var annotationSpec = AnnotationSpec
-                .builder(ClassName.get("com.fasterxml.jackson.databind.annotation", "JsonPOJOBuilder"))
-                .addMember("withPrefix", "$S", metaData.setterPrefix()).build();
-
-        builder.addAnnotation(annotationSpec);
     }
 
     private void addOnceOnlySupport() {

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/InternalRecordBuilderProcessor.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/InternalRecordBuilderProcessor.java
@@ -89,6 +89,8 @@ class InternalRecordBuilderProcessor {
             builder.addAnnotation(recordBuilderGeneratedAnnotation);
         }
 
+        addJacksonAnnotations();
+
         if (!validateMethodNameConflicts(processingEnv, recordFacade.element())) {
             builderType = Optional.empty();
             return;
@@ -197,6 +199,18 @@ class InternalRecordBuilderProcessor {
         } else {
             builder.addModifiers(Modifier.PUBLIC);
         }
+    }
+
+    private void addJacksonAnnotations() {
+        if (!metaData.addJacksonAnnotations()) {
+            return;
+        }
+
+        final var annotationSpec = AnnotationSpec
+                .builder(ClassName.get("com.fasterxml.jackson.databind.annotation", "JsonPOJOBuilder"))
+                .addMember("withPrefix", "$S", metaData.setterPrefix()).build();
+
+        builder.addAnnotation(annotationSpec);
     }
 
     private void addOnceOnlySupport() {

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/JacksonSupport.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/JacksonSupport.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2019 The original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.soabase.recordbuilder.processor;
+
+import com.palantir.javapoet.AnnotationSpec;
+import com.palantir.javapoet.ClassName;
+import com.palantir.javapoet.TypeSpec;
+import io.soabase.recordbuilder.core.RecordBuilder;
+
+import javax.annotation.processing.ProcessingEnvironment;
+
+import static javax.tools.Diagnostic.Kind.ERROR;
+
+class JacksonSupport {
+    private static final String JACKSON_2_ANNOTATION_PACKAGE = "com.fasterxml.jackson.databind.annotation";
+    private static final String JACKSON_3_ANNOTATION_PACKAGE = "tools.jackson.databind.annotation";
+
+    private static final String JSON_POJO_BUILDER = "JsonPOJOBuilder";
+
+    private final ProcessingEnvironment processingEnv;
+    private final boolean jackson2Present;
+    private final boolean jackson3Present;
+
+    JacksonSupport(ProcessingEnvironment processingEnv) {
+        this.processingEnv = processingEnv;
+        jackson2Present = isAnnotationClassPresent(JACKSON_2_ANNOTATION_PACKAGE, JSON_POJO_BUILDER);
+        jackson3Present = isAnnotationClassPresent(JACKSON_3_ANNOTATION_PACKAGE, JSON_POJO_BUILDER);
+    }
+
+    private boolean isAnnotationClassPresent(String packageName, String className) {
+        return processingEnv.getElementUtils().getTypeElement(packageName + "." + className) != null;
+    }
+
+    public void addJacksonAnnotations(RecordBuilder.Options metaData, TypeSpec.Builder builder) {
+        // return without further processing if no annotation is enabled
+        if (!anyJacksonAnnotationEnabled(metaData)) {
+            return;
+        }
+
+        switch (metaData.jackson().version()) {
+        case AUTO -> {
+            if (!jackson2Present && !jackson3Present) {
+                processingEnv.getMessager().printMessage(ERROR,
+                        "jackson.jsonPOJOBuilder is enabled but Jackson is not found on classpath. "
+                                + "Add jackson-databind dependency or disable jsonPOJOBuilder.");
+                return;
+            }
+
+            if (jackson2Present) {
+                addJacksonAnnotations(metaData, builder, JACKSON_2_ANNOTATION_PACKAGE);
+            }
+
+            if (jackson3Present) {
+                addJacksonAnnotations(metaData, builder, JACKSON_3_ANNOTATION_PACKAGE);
+            }
+        }
+
+        case JACKSON_2 -> {
+            if (!jackson2Present) {
+                processingEnv.getMessager().printMessage(ERROR,
+                        "jackson.version is set to JACKSON_2 but Jackson 2.x is not found on classpath. "
+                                + "Add jackson-databind 2.x dependency or change version to AUTO.");
+                return;
+            }
+
+            addJacksonAnnotations(metaData, builder, JACKSON_2_ANNOTATION_PACKAGE);
+        }
+
+        case JACKSON_3 -> {
+            if (!jackson3Present) {
+                processingEnv.getMessager().printMessage(ERROR,
+                        "jackson.version is set to JACKSON_3 but Jackson 3.x is not found on classpath. "
+                                + "Add jackson-databind 3.x dependency or change version to AUTO.");
+                return;
+            }
+
+            addJacksonAnnotations(metaData, builder, JACKSON_3_ANNOTATION_PACKAGE);
+        }
+        }
+    }
+
+    private boolean anyJacksonAnnotationEnabled(RecordBuilder.Options metaData) {
+        return metaData.jackson().jsonPOJOBuilder();
+    }
+
+    private void addJacksonAnnotations(RecordBuilder.Options metaData, TypeSpec.Builder builder, String packageName) {
+        if (metaData.jackson().jsonPOJOBuilder()) {
+            addJsonPOJOBuilderAnnotation(metaData, builder, packageName);
+        }
+    }
+
+    private void addJsonPOJOBuilderAnnotation(RecordBuilder.Options metaData, TypeSpec.Builder builder,
+            String packageName) {
+        final var annotationSpec = AnnotationSpec.builder(ClassName.get(packageName, JSON_POJO_BUILDER))
+                .addMember("withPrefix", "$S", metaData.setterPrefix()).build();
+
+        builder.addAnnotation(annotationSpec);
+    }
+}

--- a/record-builder-test/pom.xml
+++ b/record-builder-test/pom.xml
@@ -76,6 +76,10 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
+        <dependency>
+            <groupId>tools.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.glassfish</groupId>

--- a/record-builder-test/pom.xml
+++ b/record-builder-test/pom.xml
@@ -73,6 +73,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.glassfish</groupId>
             <artifactId>javax.el</artifactId>
             <scope>provided</scope>

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/JacksonAnnotated.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/JacksonAnnotated.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 The original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.soabase.recordbuilder.test;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.soabase.recordbuilder.core.RecordBuilder;
+
+import java.util.Map;
+
+public interface JacksonAnnotated {
+    String name();
+
+    String type();
+
+    Map<String, Object> properties();
+
+    @RecordBuilder
+    @RecordBuilder.Options(addJacksonAnnotations = true, useImmutableCollections = true, prefixEnclosingClassNames = false)
+    @JsonDeserialize(builder = JacksonAnnotatedRecordBuilder.class)
+    record JacksonAnnotatedRecord(String name, @RecordBuilder.Initializer("DEFAULT_TYPE") String type,
+            Map<String, Object> properties) implements JacksonAnnotated {
+        public static final String DEFAULT_TYPE = "dummy";
+    }
+
+    @RecordBuilder
+    @RecordBuilder.Options(addJacksonAnnotations = true, useImmutableCollections = true, prefixEnclosingClassNames = false, setterPrefix = "set")
+    @JsonDeserialize(builder = JacksonAnnotatedRecordCustomSetterPrefixBuilder.class)
+    record JacksonAnnotatedRecordCustomSetterPrefix(String name, @RecordBuilder.Initializer("DEFAULT_TYPE") String type,
+            Map<String, Object> properties) implements JacksonAnnotated {
+        public static final String DEFAULT_TYPE = "dummy";
+    }
+}

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/JacksonAnnotated.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/JacksonAnnotated.java
@@ -28,7 +28,7 @@ public interface JacksonAnnotated {
     Map<String, Object> properties();
 
     @RecordBuilder
-    @RecordBuilder.Options(addJacksonAnnotations = true, useImmutableCollections = true, prefixEnclosingClassNames = false)
+    @RecordBuilder.Options(jackson = @RecordBuilder.JacksonConfig(jsonPOJOBuilder = true), useImmutableCollections = true, prefixEnclosingClassNames = false)
     @JsonDeserialize(builder = JacksonAnnotatedRecordBuilder.class)
     record JacksonAnnotatedRecord(String name, @RecordBuilder.Initializer("DEFAULT_TYPE") String type,
             Map<String, Object> properties) implements JacksonAnnotated {
@@ -36,10 +36,32 @@ public interface JacksonAnnotated {
     }
 
     @RecordBuilder
-    @RecordBuilder.Options(addJacksonAnnotations = true, useImmutableCollections = true, prefixEnclosingClassNames = false, setterPrefix = "set")
+    @RecordBuilder.Options(jackson = @RecordBuilder.JacksonConfig(jsonPOJOBuilder = true), useImmutableCollections = true, prefixEnclosingClassNames = false, setterPrefix = "set")
     @JsonDeserialize(builder = JacksonAnnotatedRecordCustomSetterPrefixBuilder.class)
     record JacksonAnnotatedRecordCustomSetterPrefix(String name, @RecordBuilder.Initializer("DEFAULT_TYPE") String type,
             Map<String, Object> properties) implements JacksonAnnotated {
         public static final String DEFAULT_TYPE = "dummy";
+    }
+
+    @RecordBuilder
+    @RecordBuilder.Options(jackson = @RecordBuilder.JacksonConfig(jsonPOJOBuilder = true, version = RecordBuilder.JacksonVersion.JACKSON_2), useImmutableCollections = true, prefixEnclosingClassNames = false)
+    @JsonDeserialize(builder = JacksonAnnotatedRecordJackson2Builder.class)
+    record JacksonAnnotatedRecordJackson2(String name, @RecordBuilder.Initializer("DEFAULT_TYPE") String type,
+            Map<String, Object> properties) implements JacksonAnnotated {
+        public static final String DEFAULT_TYPE = "dummy";
+    }
+
+    @RecordBuilder
+    @RecordBuilder.Options(jackson = @RecordBuilder.JacksonConfig(jsonPOJOBuilder = true, version = RecordBuilder.JacksonVersion.JACKSON_3), useImmutableCollections = true, prefixEnclosingClassNames = false)
+    @tools.jackson.databind.annotation.JsonDeserialize(builder = JacksonAnnotatedRecordJackson3Builder.class)
+    record JacksonAnnotatedRecordJackson3(String name, @RecordBuilder.Initializer("DEFAULT_TYPE") String type,
+            Map<String, Object> properties) implements JacksonAnnotated {
+        public static final String DEFAULT_TYPE = "dummy";
+    }
+
+    @RecordBuilder
+    @RecordBuilder.Options(prefixEnclosingClassNames = false)
+    record JacksonAnnotatedRecordNoJackson(String name, String type, Map<String, Object> properties)
+            implements JacksonAnnotated {
     }
 }

--- a/record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestJacksonAnnotations.java
+++ b/record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestJacksonAnnotations.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 The original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.soabase.recordbuilder.test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import io.soabase.recordbuilder.test.JacksonAnnotated.JacksonAnnotatedRecord;
+import io.soabase.recordbuilder.test.JacksonAnnotated.JacksonAnnotatedRecordCustomSetterPrefix;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+class TestJacksonAnnotations {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @ParameterizedTest
+    @MethodSource("recordBuilders")
+    void addsJsonPOJOBuilderAnnotation(Class<? extends JacksonAnnotated> type, String expectedPrefix) {
+        final var annotations = Arrays.stream(type.getAnnotations()).toList();
+        assertThat(annotations).filteredOn(annotation -> annotation.annotationType().equals(JsonPOJOBuilder.class))
+                .hasSize(1).first().asInstanceOf(InstanceOfAssertFactories.type(JsonPOJOBuilder.class))
+                .satisfies(annotation -> {
+                    assertThat(annotation.withPrefix()).isEqualTo(expectedPrefix);
+                });
+    }
+
+    static Stream<Arguments> recordBuilders() {
+        return Stream.of(arguments(JacksonAnnotatedRecordBuilder.class, ""),
+                arguments(JacksonAnnotatedRecordCustomSetterPrefixBuilder.class, "set"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(classes = { JacksonAnnotatedRecord.class, JacksonAnnotatedRecordCustomSetterPrefix.class })
+    void deserializingModelInvokesBuilder(Class<? extends JacksonAnnotated> type) throws JsonProcessingException {
+        final var json = """
+                {
+                  "name" : "test"
+                }
+                """;
+
+        final var model = objectMapper.readValue(json, type);
+        assertThat(model.name()).isEqualTo("test");
+        assertThat(model.type()).isEqualTo("dummy"); // default value
+        assertThat(model.properties()).isNotNull().isEmpty(); // non-null initialized immutable collection
+    }
+}

--- a/record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestJacksonAnnotations.java
+++ b/record-builder-test/src/test/java/io/soabase/recordbuilder/test/TestJacksonAnnotations.java
@@ -20,7 +20,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import io.soabase.recordbuilder.test.JacksonAnnotated.JacksonAnnotatedRecord;
 import io.soabase.recordbuilder.test.JacksonAnnotated.JacksonAnnotatedRecordCustomSetterPrefix;
+import io.soabase.recordbuilder.test.JacksonAnnotated.JacksonAnnotatedRecordJackson2;
+import io.soabase.recordbuilder.test.JacksonAnnotated.JacksonAnnotatedRecordJackson3;
 import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -33,36 +36,128 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 class TestJacksonAnnotations {
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private static final Class<?> J2_POJO_BUILDER = JsonPOJOBuilder.class;
+    private static final Class<?> J3_POJO_BUILDER = tools.jackson.databind.annotation.JsonPOJOBuilder.class;
+
+    private final ObjectMapper jackson2ObjectMapper = new ObjectMapper();
+    private final tools.jackson.databind.ObjectMapper jackson3ObjectMapper = new tools.jackson.databind.ObjectMapper();
+
+    // -------------------------------------------------------------------------
+    // Jackson 2 annotation presence
+    // -------------------------------------------------------------------------
 
     @ParameterizedTest
-    @MethodSource("recordBuilders")
-    void addsJsonPOJOBuilderAnnotation(Class<? extends JacksonAnnotated> type, String expectedPrefix) {
+    @MethodSource("jackson2RecordBuilders")
+    void addsJackson2JsonPOJOBuilderAnnotation(Class<?> type, String expectedPrefix) {
         final var annotations = Arrays.stream(type.getAnnotations()).toList();
-        assertThat(annotations).filteredOn(annotation -> annotation.annotationType().equals(JsonPOJOBuilder.class))
-                .hasSize(1).first().asInstanceOf(InstanceOfAssertFactories.type(JsonPOJOBuilder.class))
-                .satisfies(annotation -> {
-                    assertThat(annotation.withPrefix()).isEqualTo(expectedPrefix);
-                });
+        assertThat(annotations).filteredOn(annotation -> annotation.annotationType().equals(J2_POJO_BUILDER)).hasSize(1)
+                .first().asInstanceOf(InstanceOfAssertFactories.type(JsonPOJOBuilder.class))
+                .satisfies(annotation -> assertThat(annotation.withPrefix()).isEqualTo(expectedPrefix));
     }
 
-    static Stream<Arguments> recordBuilders() {
+    static Stream<Arguments> jackson2RecordBuilders() {
         return Stream.of(arguments(JacksonAnnotatedRecordBuilder.class, ""),
-                arguments(JacksonAnnotatedRecordCustomSetterPrefixBuilder.class, "set"));
+                arguments(JacksonAnnotatedRecordCustomSetterPrefixBuilder.class, "set"),
+                arguments(JacksonAnnotatedRecordJackson2Builder.class, ""));
     }
+
+    // -------------------------------------------------------------------------
+    // Jackson 3 annotation presence
+    // -------------------------------------------------------------------------
 
     @ParameterizedTest
-    @ValueSource(classes = { JacksonAnnotatedRecord.class, JacksonAnnotatedRecordCustomSetterPrefix.class })
-    void deserializingModelInvokesBuilder(Class<? extends JacksonAnnotated> type) throws JsonProcessingException {
+    @MethodSource("jackson3RecordBuilders")
+    void addsJackson3JsonPOJOBuilderAnnotation(Class<?> type, String expectedPrefix) {
+        final var annotations = Arrays.stream(type.getAnnotations()).toList();
+        assertThat(annotations).filteredOn(annotation -> annotation.annotationType().equals(J3_POJO_BUILDER)).hasSize(1)
+                .first()
+                .asInstanceOf(InstanceOfAssertFactories.type(tools.jackson.databind.annotation.JsonPOJOBuilder.class))
+                .satisfies(annotation -> assertThat(annotation.withPrefix()).isEqualTo(expectedPrefix));
+    }
+
+    static Stream<Arguments> jackson3RecordBuilders() {
+        return Stream.of(arguments(JacksonAnnotatedRecordJackson3Builder.class, ""));
+    }
+
+    // -------------------------------------------------------------------------
+    // AUTO mode: both Jackson 2 and 3 annotations present
+    // -------------------------------------------------------------------------
+
+    @ParameterizedTest
+    @MethodSource("autoRecordBuilders")
+    void addsAnnotationsForBothVersionsInAutoMode(Class<?> type) {
+        final var annotations = Arrays.stream(type.getAnnotations()).toList();
+        assertThat(annotations).filteredOn(annotation -> annotation.annotationType().equals(J2_POJO_BUILDER))
+                .hasSize(1);
+        assertThat(annotations).filteredOn(annotation -> annotation.annotationType().equals(J3_POJO_BUILDER))
+                .hasSize(1);
+    }
+
+    static Stream<Arguments> autoRecordBuilders() {
+        return Stream.of(arguments(JacksonAnnotatedRecordBuilder.class),
+                arguments(JacksonAnnotatedRecordCustomSetterPrefixBuilder.class));
+    }
+
+    // -------------------------------------------------------------------------
+    // Version isolation: each explicit version only adds its own annotation
+    // -------------------------------------------------------------------------
+
+    @Test
+    void jackson2RecordDoesNotHaveJackson3Annotation() {
+        final var annotations = Arrays.stream(JacksonAnnotatedRecordJackson2Builder.class.getAnnotations()).toList();
+        assertThat(annotations).noneMatch(annotation -> annotation.annotationType().equals(J3_POJO_BUILDER));
+    }
+
+    @Test
+    void jackson3RecordDoesNotHaveJackson2Annotation() {
+        final var annotations = Arrays.stream(JacksonAnnotatedRecordJackson3Builder.class.getAnnotations()).toList();
+        assertThat(annotations).noneMatch(annotation -> annotation.annotationType().equals(J2_POJO_BUILDER));
+    }
+
+    // -------------------------------------------------------------------------
+    // jsonPOJOBuilder = false → no annotation added
+    // -------------------------------------------------------------------------
+
+    @Test
+    void doesNotAddJsonPOJOBuilderAnnotationWhenDisabled() {
+        final var annotations = Arrays.stream(JacksonAnnotatedRecordNoJacksonBuilder.class.getAnnotations()).toList();
+        assertThat(annotations).noneMatch(annotation -> annotation.annotationType().equals(J2_POJO_BUILDER));
+        assertThat(annotations).noneMatch(annotation -> annotation.annotationType().equals(J3_POJO_BUILDER));
+    }
+
+    // -------------------------------------------------------------------------
+    // Deserialization round-trips
+    // -------------------------------------------------------------------------
+
+    @ParameterizedTest
+    @ValueSource(classes = { JacksonAnnotatedRecord.class, JacksonAnnotatedRecordCustomSetterPrefix.class,
+            JacksonAnnotatedRecordJackson2.class })
+    void deserializingWithJackson2InvokesBuilder(Class<? extends JacksonAnnotated> type)
+            throws JsonProcessingException {
         final var json = """
                 {
                   "name" : "test"
                 }
                 """;
 
-        final var model = objectMapper.readValue(json, type);
+        final var model = jackson2ObjectMapper.readValue(json, type);
         assertThat(model.name()).isEqualTo("test");
         assertThat(model.type()).isEqualTo("dummy"); // default value
         assertThat(model.properties()).isNotNull().isEmpty(); // non-null initialized immutable collection
     }
+
+    @Test
+    void deserializingWithJackson3InvokesBuilder() throws Exception {
+        final var json = """
+                {
+                  "name" : "test"
+                }
+                """;
+
+        final var model = jackson3ObjectMapper.readValue(json, JacksonAnnotatedRecordJackson3.class);
+        assertThat(model.name()).isEqualTo("test");
+        assertThat(model.type()).isEqualTo("dummy"); // default value
+        assertThat(model.properties()).isNotNull().isEmpty(); // non-null initialized immutable collection
+    }
+
 }


### PR DESCRIPTION
Adds a new option structure to instruct record-builder to add a Jackson `@JsonPOJOBuilder` annotation to the generated builder. While this implements library-specifics, it does not add Jackson as dependency (only on the test module).

**Example usage:**

Auto-detect Jackson version (default)
```java
@RecordBuilder.Options(jackson = @RecordBuilder.JacksonConfig(jsonPOJOBuilder = true))
```

Explicitly add Jackson 2.x annotation (fail if J2 is not available):
```java
@RecordBuilder.Options(
    jackson = @RecordBuilder.JacksonConfig(
        jsonPOJOBuilder = true,
        version = JacksonVersion.JACKSON_2
    )
)
```

With custom setter prefix:
```java
@RecordBuilder.Options(
    jackson = @RecordBuilder.JacksonConfig(jsonPOJOBuilder = true),
    setterPrefix = "set"
)
```

Closes #229