### PR TITLE
Add missing annotations to builder all-args constructor

### DIFF
--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/InternalRecordBuilderProcessor.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/InternalRecordBuilderProcessor.java
@@ -585,7 +585,9 @@ class InternalRecordBuilderProcessor {
         var constructorBuilder = MethodSpec.constructorBuilder().addModifiers(constructorVisibilityModifier)
                 .addAnnotation(generatedRecordBuilderAnnotation);
         recordComponents.forEach(component -> {
-            constructorBuilder.addParameter(component.typeName(), component.name());
+            var parameterSpecBuilder = ParameterSpec.builder(component.typeName(), component.name());
+            addConstructorAnnotations(component, parameterSpecBuilder);
+            constructorBuilder.addParameter(parameterSpecBuilder.build());
             constructorBuilder.addStatement("this.$L = $L", component.name(), component.name());
         });
         builder.addMethod(constructorBuilder.build());


### PR DESCRIPTION
Motivation
----------

I am working with record-builder and integrating tools like NullAway. Everything was working great, but I noticed that the generated builder all-args constructor doesn't include the annotations found on the record. This causes tools like NullAway to fail when inspecting the builder as a nullable accessor could be trying to set a value on to a non-nullable constructor argument.

Modifications
-------------

The fix is relatively simple. There's already an addConstructorAnnotations method designed to perform this action. It was not being used for the all-args constructor. I've added its usage and the annotations started appearing.

Result
------

The result is the generated builder all-args constructor mirrors the annotations found on the record