### PR TITLE
Add support for detected RecordBuilder components

### DIFF
--- a/options.md
+++ b/options.md
@@ -56,20 +56,21 @@ The names used for generated methods, classes, etc. can be changed via the follo
 
 ## Miscellaneous
 
-| option                                                                     | details                                                                                                                                                          |
-|----------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `@RecordBuilder.Options(inheritComponentAnnotations = true/false)`         | If true, any annotations (if applicable) on record components are copied to the builder methods. The default is `true`.                                          |
-| `@RecordBuilder.Options(publicBuilderConstructors = true/false)`           | Makes the generated builder's constructors public. The default is `false`.                                                                                       |
-| `@RecordBuilder.Options(builderClassModifiers = {}})`                      | Any additional `javax.lang.model.element.Modifier` you wish to apply to the builder.                                                                             |
-| `@RecordBuilder.Options(beanClassName = "Foo")`                            | If set, the Builder will contain an internal interface with this name.                                                                                           |
-| `@RecordBuilder.Options(addClassRetainedGenerated = true/false)`           | If true, generated classes are annotated with `RecordBuilderGenerated`. The default is `false`.                                                                  |
-| `@RecordBuilder.Options(addStaticBuilder = true/false)`                    | If true, a functional-style builder is added so that record instances can be instantiated without `new()`. The default is `true`.                                |
-| `@RecordBuilder.Options(inheritComponentAnnotations = true/false)`         | If true, any annotations (if applicable) on record components are copied to the builder methods. The default is `true`.                                          |
-| `@RecordBuilder.Options(addConcreteSettersForOptional = <mode>)`           | Add non-optional setter methods for optional record components. The default is `ConcreteSettersForOptionalMode.DISABLED`.                                        |
-| `@RecordBuilder.Options(nullableAnnotationClass = "com.foo.Nullable")`     | Nullability annotation to use when RecordBuilder needs to add one.                                                                                               |
-| `@RecordBuilder.Options(useValidationApi = true/false)`                    | Pass built records through the Java Validation API if it's available in the classpath. The default is `false`.                                                   |
-| `@RecordBuilder.Options(builderMode = BuilderMode.XXX)`                    | Whether to add standard builder, staged builder or both. The default is `BuilderMode.STANDARD`.                                                                  |
-| `@RecordBuilder.Options(onceOnlyAssignment = true/false)`                  | If true, attributes can be set/assigned only 1 time. Attempts to reassign/reset attributes will throw `java.lang.IllegalStateException`. The default is `false`. |
+| option                                                                 | details                                                                                                                                                          |
+|------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `@RecordBuilder.Options(inheritComponentAnnotations = true/false)`     | If true, any annotations (if applicable) on record components are copied to the builder methods. The default is `true`.                                          |
+| `@RecordBuilder.Options(publicBuilderConstructors = true/false)`       | Makes the generated builder's constructors public. The default is `false`.                                                                                       |
+| `@RecordBuilder.Options(builderClassModifiers = {}})`                  | Any additional `javax.lang.model.element.Modifier` you wish to apply to the builder.                                                                             |
+| `@RecordBuilder.Options(beanClassName = "Foo")`                        | If set, the Builder will contain an internal interface with this name.                                                                                           |
+| `@RecordBuilder.Options(addClassRetainedGenerated = true/false)`       | If true, generated classes are annotated with `RecordBuilderGenerated`. The default is `false`.                                                                  |
+| `@RecordBuilder.Options(addStaticBuilder = true/false)`                | If true, a functional-style builder is added so that record instances can be instantiated without `new()`. The default is `true`.                                |
+| `@RecordBuilder.Options(inheritComponentAnnotations = true/false)`     | If true, any annotations (if applicable) on record components are copied to the builder methods. The default is `true`.                                          |
+| `@RecordBuilder.Options(addConcreteSettersForOptional = <mode>)`       | Add non-optional setter methods for optional record components. The default is `ConcreteSettersForOptionalMode.DISABLED`.                                        |
+| `@RecordBuilder.Options(nullableAnnotationClass = "com.foo.Nullable")` | Nullability annotation to use when RecordBuilder needs to add one.                                                                                               |
+| `@RecordBuilder.Options(useValidationApi = true/false)`                | Pass built records through the Java Validation API if it's available in the classpath. The default is `false`.                                                   |
+| `@RecordBuilder.Options(builderMode = BuilderMode.XXX)`                | Whether to add standard builder, staged builder or both. The default is `BuilderMode.STANDARD`.                                                                  |
+| `@RecordBuilder.Options(onceOnlyAssignment = true/false)`              | If true, attributes can be set/assigned only 1 time. Attempts to reassign/reset attributes will throw `java.lang.IllegalStateException`. The default is `false`. |
+| `@RecordBuilder.Options(detectNestedRecordBuilders = true)`            | If set, detects if a component is, itself, annotated with `@RecordBuilder` and, if so, adds a setter that is a `Consumer` of a builder for that record.          |
 
 ### Staged Builders
 

--- a/record-builder-core/src/main/java/io/soabase/recordbuilder/core/RecordBuilder.java
+++ b/record-builder-core/src/main/java/io/soabase/recordbuilder/core/RecordBuilder.java
@@ -365,7 +365,7 @@ public @interface RecordBuilder {
          * are nested builder consumers so that you can do, for example,
          * {@code myRecord.withNestedRecord(nestedBuilder -> nestedBuilder.field1(...).field2(...))}
          */
-        boolean detectNestedRecordBuilders() default false;
+        boolean detectNestedRecordBuilders() default true;
     }
 
     @Retention(RetentionPolicy.CLASS)

--- a/record-builder-core/src/main/java/io/soabase/recordbuilder/core/RecordBuilder.java
+++ b/record-builder-core/src/main/java/io/soabase/recordbuilder/core/RecordBuilder.java
@@ -359,6 +359,13 @@ public @interface RecordBuilder {
          * @see #nullablePattern
          */
         boolean defaultNotNull() default false;
+
+        /**
+         * If true, record components that are themselves {@code @RecordBuilder} records will have builder methods that
+         * are nested builder consumers so that you can do, for example,
+         * {@code myRecord.withNestedRecord(nestedBuilder -> nestedBuilder.field1(...).field2(...))}
+         */
+        boolean detectNestedRecordBuilders() default false;
     }
 
     @Retention(RetentionPolicy.CLASS)

--- a/record-builder-core/src/main/java/io/soabase/recordbuilder/core/RecordBuilderFull.java
+++ b/record-builder-core/src/main/java/io/soabase/recordbuilder/core/RecordBuilderFull.java
@@ -20,7 +20,7 @@ import java.lang.annotation.*;
 /**
  * An alternate form of {@code @RecordBuilder} that has most optional features turned on
  */
-@RecordBuilder.Template(options = @RecordBuilder.Options(interpretNotNulls = true, useImmutableCollections = true, addSingleItemCollectionBuilders = true, addFunctionalMethodsToWith = true, addClassRetainedGenerated = true, detectNestedRecordBuilders = true))
+@RecordBuilder.Template(options = @RecordBuilder.Options(interpretNotNulls = true, useImmutableCollections = true, addSingleItemCollectionBuilders = true, addFunctionalMethodsToWith = true, addClassRetainedGenerated = true))
 @Retention(RetentionPolicy.SOURCE)
 @Target({ ElementType.TYPE, ElementType.METHOD })
 @Inherited

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/ElementUtils.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/ElementUtils.java
@@ -19,6 +19,7 @@ import com.palantir.javapoet.ClassName;
 import com.palantir.javapoet.ParameterizedTypeName;
 import com.palantir.javapoet.TypeName;
 import com.palantir.javapoet.TypeVariableName;
+import io.soabase.recordbuilder.core.RecordBuilder;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.*;
@@ -135,8 +136,9 @@ public class ElementUtils {
             List<? extends AnnotationMirror> canonicalConstructorAnnotations) {
         var typeName = TypeName.get(recordComponent.asType());
         var rawTypeName = TypeName.get(processingEnv.getTypeUtils().erasure(recordComponent.asType()));
-        return new RecordClassType(typeName, rawTypeName, recordComponent.getSimpleName().toString(),
-                recordComponent.getSimpleName().toString(), accessorAnnotations, canonicalConstructorAnnotations);
+        return new RecordClassType(recordComponent.asType().getKind(), typeName, rawTypeName,
+                recordComponent.getSimpleName().toString(), recordComponent.getSimpleName().toString(),
+                accessorAnnotations, canonicalConstructorAnnotations);
     }
 
     public static String getWithMethodName(ClassType component, String prefix) {
@@ -178,6 +180,12 @@ public class ElementUtils {
             return getNamePrefix(element.getEnclosingElement()) + element.getSimpleName().toString();
         }
         return "";
+    }
+
+    public static RecordBuilder.Options getMetaData(ProcessingEnvironment processingEnv, Element element) {
+        var recordSpecificMetaData = element.getAnnotation(RecordBuilder.Options.class);
+        return (recordSpecificMetaData != null) ? recordSpecificMetaData
+                : RecordBuilderOptions.build(processingEnv.getOptions());
     }
 
     private ElementUtils() {

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/InternalDeconstructorProcessor.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/InternalDeconstructorProcessor.java
@@ -188,8 +188,8 @@ class InternalDeconstructorProcessor {
                             .stream().filter(annotation -> !annotation.getAnnotationType().asElement().getSimpleName()
                                     .toString().equals(DeconstructorAccessor.class.getSimpleName()))
                             .toList();
-                    var type = new RecordClassType(typeName, rawTypeName, name,
-                            executableElement.getSimpleName().toString(), annotationMirrors, List.of());
+                    var type = new RecordClassType(executableElement.getReturnType().getKind(), typeName, rawTypeName,
+                            name, executableElement.getSimpleName().toString(), annotationMirrors, List.of());
                     var orderedType = Map.entry(deconstructorAccessor.order(), type);
                     return Stream.of(orderedType);
                 }).sorted((o1, o2) -> {
@@ -229,9 +229,9 @@ class InternalDeconstructorProcessor {
         return executableElement.getParameters().stream().map(parameter -> {
             ValidatedParameter validatedParameter = validateParameter(parameter.getSimpleName().toString(),
                     parameter.asType());
-            return new RecordClassType(validatedParameter.typeName, validatedParameter.rawTypeName,
-                    parameter.getSimpleName().toString(), parameter.getSimpleName().toString(),
-                    parameter.getAnnotationMirrors(), List.of());
+            return new RecordClassType(parameter.asType().getKind(), validatedParameter.typeName,
+                    validatedParameter.rawTypeName, parameter.getSimpleName().toString(),
+                    parameter.getSimpleName().toString(), parameter.getAnnotationMirrors(), List.of());
         }).toList();
     }
 

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/NestedBuilder.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/NestedBuilder.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2019 The original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.soabase.recordbuilder.processor;
+
+import com.palantir.javapoet.TypeName;
+import io.soabase.recordbuilder.core.RecordBuilder;
+
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+record NestedBuilder(Optional<RecordBuilder.Options> builderOptions) {
+    private static final NestedBuilder NONE = new NestedBuilder(Optional.empty());
+
+    private static final TypeName recordBuilderType = TypeName.get(RecordBuilder.class);
+    private static final TypeName recordBuilderTemplateType = TypeName.get(RecordBuilder.Template.class);
+
+    static NestedBuilder build(ProcessingEnvironment processingEnv, RecordBuilder.Options metaData,
+            RecordClassType component) {
+        if (!metaData.detectNestedRecordBuilders()) {
+            return NONE;
+        }
+
+        if (component.typeKind() != TypeKind.DECLARED) {
+            return NONE;
+        }
+
+        TypeElement typeElement = processingEnv.getElementUtils().getTypeElement(component.rawTypeName().toString());
+        if ((typeElement == null) || (typeElement.asType() == null)) {
+            return NONE;
+        }
+
+        TypeMirror recordBuilderMirror = processingEnv.getElementUtils().getTypeElement(recordBuilderType.toString())
+                .asType();
+        TypeMirror recordBuilderTemplateMirror = processingEnv.getElementUtils()
+                .getTypeElement(recordBuilderTemplateType.toString()).asType();
+
+        Optional<RecordBuilder.Options> maybeOptions = typeElement.getAnnotationMirrors().stream()
+                .flatMap(annotation -> {
+                    Optional<? extends AnnotationMirror> annotationMirror = ElementUtils.findAnnotationMirror(
+                            processingEnv, annotation.getAnnotationType().asElement(),
+                            recordBuilderTemplateType.toString());
+                    if (annotationMirror.isPresent()) {
+                        RecordBuilder.Options newOptions = ElementUtils.getMetaData(processingEnv,
+                                annotation.getAnnotationType().asElement());
+                        return Stream.of(newOptions);
+                    }
+                    return Stream.empty();
+                }).findFirst();
+
+        if (maybeOptions.isEmpty()) {
+            maybeOptions = processingEnv.getElementUtils().getAllAnnotationMirrors(typeElement).stream()
+                    .flatMap(annotationMirror -> {
+                        if (processingEnv.getTypeUtils().isSameType(annotationMirror.getAnnotationType(),
+                                recordBuilderMirror)) {
+                            return Stream.of(ElementUtils.getMetaData(processingEnv, typeElement));
+                        }
+                        if (processingEnv.getTypeUtils().isSameType(annotationMirror.getAnnotationType(),
+                                recordBuilderTemplateMirror)) {
+                            RecordBuilder.Options options = recordBuilderTemplateMirror
+                                    .getAnnotation(RecordBuilder.Options.class);
+                            return Stream.of(options);
+                        }
+                        return Stream.empty();
+                    }).findFirst();
+        }
+        if (maybeOptions.isEmpty()) {
+            return NONE;
+        }
+
+        RecordBuilder.Options options = maybeOptions.get();
+        return new NestedBuilder(Optional.of(options));
+    }
+}

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/RecordBuilderProcessor.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/RecordBuilderProcessor.java
@@ -115,9 +115,7 @@ public class RecordBuilderProcessor extends AbstractProcessor {
     }
 
     private RecordBuilder.Options getMetaData(Element element) {
-        var recordSpecificMetaData = element.getAnnotation(RecordBuilder.Options.class);
-        return (recordSpecificMetaData != null) ? recordSpecificMetaData
-                : RecordBuilderOptions.build(processingEnv.getOptions());
+        return ElementUtils.getMetaData(processingEnv, element);
     }
 
     private void processIncludes(Element element, RecordBuilder.Options metaData, String annotationClass) {

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/RecordClassType.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/RecordClassType.java
@@ -18,22 +18,29 @@ package io.soabase.recordbuilder.processor;
 import com.palantir.javapoet.TypeName;
 
 import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.type.TypeKind;
 import java.util.List;
 
 public class RecordClassType extends ClassType {
+    private final TypeKind typeKind;
     private final TypeName rawTypeName;
     private final String accessorName;
     private final List<? extends AnnotationMirror> accessorAnnotations;
     private final List<? extends AnnotationMirror> canonicalConstructorAnnotations;
 
-    public RecordClassType(TypeName typeName, TypeName rawTypeName, String name, String accessorName,
+    public RecordClassType(TypeKind typeKind, TypeName typeName, TypeName rawTypeName, String name, String accessorName,
             List<? extends AnnotationMirror> accessorAnnotations,
             List<? extends AnnotationMirror> canonicalConstructorAnnotations) {
         super(typeName, name);
+        this.typeKind = typeKind;
         this.rawTypeName = rawTypeName;
         this.accessorName = accessorName;
         this.accessorAnnotations = accessorAnnotations;
         this.canonicalConstructorAnnotations = canonicalConstructorAnnotations;
+    }
+
+    public TypeKind typeKind() {
+        return typeKind;
     }
 
     public String accessorName() {

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/Annotated.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/Annotated.java
@@ -22,5 +22,6 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Null;
 
 @RecordBuilder
+@RecordBuilder.Options(detectNestedRecordBuilders = true)
 public record Annotated(@NotNull @Null String hey, @Min(10) @Max(100) int i, double d) {
 }

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/CollectionCopying.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/CollectionCopying.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import java.util.Set;
 
 @RecordBuilder
-@RecordBuilder.Options(addSingleItemCollectionBuilders = true, useImmutableCollections = true, mutableListClassName = "PersonalizedMutableList")
+@RecordBuilder.Options(addSingleItemCollectionBuilders = true, useImmutableCollections = true, mutableListClassName = "PersonalizedMutableList", detectNestedRecordBuilders = true)
 public record CollectionCopying<T>(List<String> list, Set<T> set, Map<Instant, T> map, Collection<T> collection,
         int count) implements CollectionCopyingBuilder.With<T> {
 }

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/CollectionRecord.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/CollectionRecord.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import java.util.Set;
 
 @RecordBuilder
-@RecordBuilder.Options(useImmutableCollections = true, addFunctionalMethodsToWith = true)
+@RecordBuilder.Options(useImmutableCollections = true, addFunctionalMethodsToWith = true, detectNestedRecordBuilders = true)
 public record CollectionRecord<T, X extends Point>(List<T> l, Set<T> s, Map<T, X> m, Collection<X> c)
         implements CollectionRecordBuilder.With<T, X> {
     public static void main(String[] args) {

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/DuplicateMethodNames.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/DuplicateMethodNames.java
@@ -18,6 +18,6 @@ package io.soabase.recordbuilder.test;
 import io.soabase.recordbuilder.core.RecordBuilder;
 
 @RecordBuilder
-@RecordBuilder.Options(builderMode = RecordBuilder.BuilderMode.STANDARD_AND_STAGED, builderMethodName = "notBuilder", buildMethodName = "notBuild", stagedBuilderMethodName = "notStagedBuilder")
+@RecordBuilder.Options(builderMode = RecordBuilder.BuilderMode.STANDARD_AND_STAGED, builderMethodName = "notBuilder", buildMethodName = "notBuild", stagedBuilderMethodName = "notStagedBuilder", detectNestedRecordBuilders = true)
 public record DuplicateMethodNames(int builder, int build, int from, int stream, int stagedBuilder) {
 }

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/MyTemplate.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/MyTemplate.java
@@ -17,6 +17,6 @@ package io.soabase.recordbuilder.test;
 
 import io.soabase.recordbuilder.core.RecordBuilder;
 
-@RecordBuilder.Template(options = @RecordBuilder.Options(fileComment = "This is a test", withClassName = "Com"))
+@RecordBuilder.Template(options = @RecordBuilder.Options(fileComment = "This is a test", withClassName = "Com", detectNestedRecordBuilders = true))
 public @interface MyTemplate {
 }

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/WildcardSingleItems.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/WildcardSingleItems.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import java.util.Set;
 
 @RecordBuilder
-@RecordBuilder.Options(addSingleItemCollectionBuilders = true, useImmutableCollections = true)
+@RecordBuilder.Options(addSingleItemCollectionBuilders = true, useImmutableCollections = true, detectNestedRecordBuilders = true)
 public record WildcardSingleItems<T>(List<? extends String> strings, Set<? extends List<? extends T>> sets,
         Map<? extends Instant, ? extends T> map, Collection<? extends T> collection)
         implements WildcardSingleItemsBuilder.With<T> {

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/nested/Address.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/nested/Address.java
@@ -13,16 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.soabase.recordbuilder.core;
+package io.soabase.recordbuilder.test.nested;
 
-import java.lang.annotation.*;
+import io.soabase.recordbuilder.core.RecordBuilderFull;
 
-/**
- * An alternate form of {@code @RecordBuilder} that has most optional features turned on
- */
-@RecordBuilder.Template(options = @RecordBuilder.Options(interpretNotNulls = true, useImmutableCollections = true, addSingleItemCollectionBuilders = true, addFunctionalMethodsToWith = true, addClassRetainedGenerated = true, detectNestedRecordBuilders = true))
-@Retention(RetentionPolicy.SOURCE)
-@Target({ ElementType.TYPE, ElementType.METHOD })
-@Inherited
-public @interface RecordBuilderFull {
+@RecordBuilderFull
+public record Address(String address, CityState cityState, String country) implements AddressBuilder.With {
 }

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/nested/BigOlNestedContainer.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/nested/BigOlNestedContainer.java
@@ -13,16 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.soabase.recordbuilder.core;
+package io.soabase.recordbuilder.test.nested;
 
-import java.lang.annotation.*;
+import io.soabase.recordbuilder.core.RecordBuilderFull;
+import io.soabase.recordbuilder.test.*;
 
-/**
- * An alternate form of {@code @RecordBuilder} that has most optional features turned on
- */
-@RecordBuilder.Template(options = @RecordBuilder.Options(interpretNotNulls = true, useImmutableCollections = true, addSingleItemCollectionBuilders = true, addFunctionalMethodsToWith = true, addClassRetainedGenerated = true, detectNestedRecordBuilders = true))
-@Retention(RetentionPolicy.SOURCE)
-@Target({ ElementType.TYPE, ElementType.METHOD })
-@Inherited
-public @interface RecordBuilderFull {
+@RecordBuilderFull
+public record BigOlNestedContainer<T, X extends Point>(Annotated annotated, CollectionCopying<T> collectionCopying,
+        CollectionRecord<T, X> collectionRecord, FullRecord fullRecord, ConvertRequest convertRequest,
+        TemplateTest templateTest, WildcardSingleItems<T> wildcardSingleItems,
+        DuplicateMethodNames duplicateMethodNames, BigOlNestedContainer<T, X> recursive)
+        implements BigOlNestedContainerBuilder.With<T, X> {
 }

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/nested/CityState.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/nested/CityState.java
@@ -13,16 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.soabase.recordbuilder.core;
+package io.soabase.recordbuilder.test.nested;
 
-import java.lang.annotation.*;
+import io.soabase.recordbuilder.core.RecordBuilder;
 
-/**
- * An alternate form of {@code @RecordBuilder} that has most optional features turned on
- */
-@RecordBuilder.Template(options = @RecordBuilder.Options(interpretNotNulls = true, useImmutableCollections = true, addSingleItemCollectionBuilders = true, addFunctionalMethodsToWith = true, addClassRetainedGenerated = true, detectNestedRecordBuilders = true))
-@Retention(RetentionPolicy.SOURCE)
-@Target({ ElementType.TYPE, ElementType.METHOD })
-@Inherited
-public @interface RecordBuilderFull {
+@RecordBuilder
+public record CityState(String city, String state) implements CityStateBuilder.With {
 }

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/nested/ConvertRequest.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/nested/ConvertRequest.java
@@ -13,16 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.soabase.recordbuilder.core;
+package io.soabase.recordbuilder.test.nested;
 
-import java.lang.annotation.*;
+import io.soabase.recordbuilder.test.naming.Builder;
 
-/**
- * An alternate form of {@code @RecordBuilder} that has most optional features turned on
- */
-@RecordBuilder.Template(options = @RecordBuilder.Options(interpretNotNulls = true, useImmutableCollections = true, addSingleItemCollectionBuilders = true, addFunctionalMethodsToWith = true, addClassRetainedGenerated = true, detectNestedRecordBuilders = true))
-@Retention(RetentionPolicy.SOURCE)
-@Target({ ElementType.TYPE, ElementType.METHOD })
-@Inherited
-public @interface RecordBuilderFull {
+@Builder
+record ConvertRequest(double from, double to) {
 }

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/nested/Employee.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/nested/Employee.java
@@ -13,16 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.soabase.recordbuilder.core;
+package io.soabase.recordbuilder.test.nested;
 
-import java.lang.annotation.*;
+import io.soabase.recordbuilder.core.RecordBuilderFull;
 
-/**
- * An alternate form of {@code @RecordBuilder} that has most optional features turned on
- */
-@RecordBuilder.Template(options = @RecordBuilder.Options(interpretNotNulls = true, useImmutableCollections = true, addSingleItemCollectionBuilders = true, addFunctionalMethodsToWith = true, addClassRetainedGenerated = true, detectNestedRecordBuilders = true))
-@Retention(RetentionPolicy.SOURCE)
-@Target({ ElementType.TYPE, ElementType.METHOD })
-@Inherited
-public @interface RecordBuilderFull {
+@RecordBuilderFull
+public record Employee(String firstName, String lastName, Address address) implements EmployeeBuilder.With {
 }

--- a/record-builder-test/src/test/java/io/soabase/recordbuilder/test/nested/TestNestedBuilders.java
+++ b/record-builder-test/src/test/java/io/soabase/recordbuilder/test/nested/TestNestedBuilders.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 The original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.soabase.recordbuilder.test.nested;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestNestedBuilders {
+    @Test
+    public void testNestedBuilders() {
+        Employee employee = EmployeeBuilder.builder().firstName("John").lastName("Doe").address(
+                b -> b.address("123 Main St").cityState(cs -> cs.city("Springfield").state("IL")).country("USA"))
+                .build();
+
+        Employee employee2 = employee.with(b -> b.address(
+                a -> a.cityState(cs -> cs.city("Shelbyville")).country("Nope").cityState(cs -> cs.state("Good"))));
+        assertThat(employee2).isEqualTo(
+                new Employee("John", "Doe", new Address("123 Main St", new CityState("Shelbyville", "Good"), "Nope")));
+
+        Employee employee3 = employee.withAddress(a -> a.cityState(cs -> cs.city("Shelbyville2")));
+        assertThat(employee3).isEqualTo(
+                new Employee("John", "Doe", new Address("123 Main St", new CityState("Shelbyville2", "IL"), "USA")));
+
+        Employee employee4 = employee.withAddress(a -> a.country("Israel"));
+        assertThat(employee4).isEqualTo(
+                new Employee("John", "Doe", new Address("123 Main St", new CityState("Springfield", "IL"), "Israel")));
+    }
+}


### PR DESCRIPTION
If a record component is, itself, annotated with `@RecordBuilder` or a template, adds a setter that takes a `Consumer` which accepts a builder for that component so that you can easily build/with nested records that have a builder.

See [TestNestedBuilders.java](https://github.com/Randgalt/record-builder/blob/jordanz/nested-builders/record-builder-test/src/test/java/io/soabase/recordbuilder/test/nested/TestNestedBuilders.java) for an example.