### PR TITLE
Don't add annotation if it doesn't have the correct `@Target`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
         <jakarta-validation-api-version>3.1.0</jakarta-validation-api-version>
         <javax-el-version>3.0.1-b09</javax-el-version>
         <central-publishing-maven-plugin-version>0.7.0</central-publishing-maven-plugin-version>
+        <jspecify-version>1.0.0</jspecify-version>
     </properties>
 
     <name>Record Builder</name>
@@ -169,6 +170,12 @@
                 <groupId>org.glassfish</groupId>
                 <artifactId>javax.el</artifactId>
                 <version>${javax-el-version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jspecify</groupId>
+                <artifactId>jspecify</artifactId>
+                <version>${jspecify-version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/InternalDeconstructorProcessor.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/InternalDeconstructorProcessor.java
@@ -26,6 +26,7 @@ import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.tools.Diagnostic;
+import java.lang.annotation.ElementType;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -40,6 +41,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static io.soabase.recordbuilder.processor.ElementUtils.generateName;
+import static io.soabase.recordbuilder.processor.ElementUtils.hasAnnotationTarget;
 import static io.soabase.recordbuilder.processor.RecordBuilderProcessor.generatedRecordBuilderAnnotation;
 import static io.soabase.recordbuilder.processor.RecordBuilderProcessor.recordBuilderGeneratedAnnotation;
 
@@ -275,8 +277,9 @@ class InternalDeconstructorProcessor {
         recordComponents.forEach(component -> {
             ParameterSpec.Builder componentBuilder = ParameterSpec.builder(component.typeName(), component.name());
             if (deconstructor.inheritAnnotations()) {
-                componentBuilder
-                        .addAnnotations(component.getAccessorAnnotations().stream().map(AnnotationSpec::get).toList());
+                componentBuilder.addAnnotations(component
+                        .getAccessorAnnotations().stream().filter(annotationMirror -> hasAnnotationTarget(processingEnv, annotationMirror, ElementType.METHOD))
+                        .map(AnnotationSpec::get).toList());
             }
             constructorBuilder.addParameter(componentBuilder.build());
         });

--- a/record-builder-test/pom.xml
+++ b/record-builder-test/pom.xml
@@ -46,6 +46,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.soabase.record-builder</groupId>
             <artifactId>record-builder-processor</artifactId>
             <scope>provided</scope>

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/jspecify/MyRecord.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/jspecify/MyRecord.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 The original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.soabase.recordbuilder.test.jspecify;
+
+import org.jspecify.annotations.Nullable;
+
+@RecordBuilderCustom
+public record MyRecord(@Nullable MyEnum myEnum) {
+
+    public enum MyEnum {
+        VAL1, VAL2
+    }
+}

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/jspecify/RecordBuilderCustom.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/jspecify/RecordBuilderCustom.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 The original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.soabase.recordbuilder.test.jspecify;
+
+import io.soabase.recordbuilder.core.RecordBuilder;
+
+import java.lang.annotation.*;
+
+@RecordBuilder.Template(options = @RecordBuilder.Options(interpretNotNulls = true, prefixEnclosingClassNames = false, addClassRetainedGenerated = true))
+@Retention(RetentionPolicy.SOURCE)
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Inherited
+public @interface RecordBuilderCustom {
+}


### PR DESCRIPTION
This is further refinement of the `TypeUse` annotation issue. In this case when we copy annotations from the record that target of the annotation will be different than `ElementType.RECORD_COMPONENT` or `ElementType.TYPE_USE`, etc. Ensure that the annotation has a compatible `@Target` when adding.

Added a test record for this as well provided by @facboy

Fixes #258