### PR TITLE
Warn if the record type is ERROR

### DIFF
--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/ElementUtils.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/ElementUtils.java
@@ -23,7 +23,9 @@ import com.palantir.javapoet.TypeVariableName;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.*;
+import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
+import javax.tools.Diagnostic;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 import java.util.Collections;
@@ -178,6 +180,13 @@ public class ElementUtils {
     public static RecordClassType getRecordClassType(ProcessingEnvironment processingEnv,
             RecordComponentElement recordComponent, List<? extends AnnotationMirror> accessorAnnotations,
             List<? extends AnnotationMirror> canonicalConstructorAnnotations) {
+        if (recordComponent.asType().getKind() == TypeKind.ERROR) {
+            processingEnv.getMessager().printMessage(Diagnostic.Kind.MANDATORY_WARNING,
+                    "Unable to resolve type/package for record component \"%s %s\" of \"%s\". You can usually work around this by spelling the class's FQPN."
+                            .formatted(recordComponent.asType(), recordComponent.getSimpleName(),
+                                    recordComponent.getEnclosingElement()));
+        }
+
         var typeName = TypeName.get(recordComponent.asType());
         var rawTypeName = TypeName.get(processingEnv.getTypeUtils().erasure(recordComponent.asType()));
         return new RecordClassType(typeName, rawTypeName, recordComponent.getSimpleName().toString(),

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/circular/Parent.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/circular/Parent.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 The original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.soabase.recordbuilder.test.circular;
+
+import io.soabase.recordbuilder.core.RecordBuilder;
+
+@RecordBuilder
+public record Parent(String foo) {
+}

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/circular/nested/Child.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/circular/nested/Child.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 The original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.soabase.recordbuilder.test.circular.nested;
+
+import io.soabase.recordbuilder.core.RecordBuilder;
+
+@RecordBuilder
+public record Child(io.soabase.recordbuilder.test.circular.ParentBuilder parentBuilder) {
+}


### PR DESCRIPTION
This can happen with circular/nested references. It appears to be a bug in the JDK compiler. You can work around it by using the FQPN so this warning instructs to do that.

Relates to #269