### PR TITLE
Add @SuppressWarnings to generated classes to fix @Deprecated components

### DIFF
--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/CollectionBuilderUtils.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/CollectionBuilderUtils.java
@@ -23,9 +23,7 @@ import java.io.Serial;
 import java.util.*;
 import java.util.regex.Pattern;
 
-import static io.soabase.recordbuilder.processor.RecordBuilderProcessor.generatedRecordBuilderAnnotation;
-import static io.soabase.recordbuilder.processor.RecordBuilderProcessor.recordBuilderGeneratedAnnotation;
-import static io.soabase.recordbuilder.processor.RecordBuilderProcessor.suppressWarningsAnnotation;
+import static io.soabase.recordbuilder.processor.RecordBuilderProcessor.*;
 
 class CollectionBuilderUtils {
     private final boolean useImmutableCollections;
@@ -388,9 +386,6 @@ class CollectionBuilderUtils {
         var extendedParameterizedType = ParameterizedTypeName.get(ClassName.get(abstractType), wildCardTypeArguments);
 
         MethodSpec.Builder methodBuilder = MethodSpec.methodBuilder(name);
-        if (!useImmutableCollections) {
-            methodBuilder.addAnnotation(suppressWarningsAnnotation);
-        }
         return methodBuilder.addAnnotation(generatedRecordBuilderAnnotation)
                 .addModifiers(Modifier.PRIVATE, Modifier.STATIC).addTypeVariables(Arrays.asList(typeVariables))
                 .returns(parameterizedType).addParameter(extendedParameterizedType, "o").addStatement(code).build();
@@ -485,6 +480,8 @@ class CollectionBuilderUtils {
         if (addClassRetainedGenerated) {
             builder.addAnnotation(recordBuilderGeneratedAnnotation);
         }
+
+        builder.addAnnotation(suppressWarningsAnnotation);
 
         return builder.build();
     }

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/InternalDeconstructorProcessor.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/InternalDeconstructorProcessor.java
@@ -44,8 +44,7 @@ import static io.soabase.recordbuilder.processor.ElementUtils.generateName;
 import static io.soabase.recordbuilder.processor.ElementUtils.hasAnnotationTarget;
 import static io.soabase.recordbuilder.processor.InternalRecordBuilderProcessor.capitalize;
 import static io.soabase.recordbuilder.processor.ParameterSpecUtil.createParameterSpec;
-import static io.soabase.recordbuilder.processor.RecordBuilderProcessor.generatedRecordBuilderAnnotation;
-import static io.soabase.recordbuilder.processor.RecordBuilderProcessor.recordBuilderGeneratedAnnotation;
+import static io.soabase.recordbuilder.processor.RecordBuilderProcessor.*;
 
 class InternalDeconstructorProcessor {
     private final String packageName;
@@ -111,6 +110,8 @@ class InternalDeconstructorProcessor {
         if (metaData.addClassRetainedGenerated()) {
             builder.addAnnotation(recordBuilderGeneratedAnnotation);
         }
+
+        builder.addAnnotation(suppressWarningsAnnotation);
 
         addVisibility(element.getModifiers());
         addRecordComponents();

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/InternalRecordBuilderProcessor.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/InternalRecordBuilderProcessor.java
@@ -38,8 +38,7 @@ import static io.soabase.recordbuilder.processor.CollectionBuilderUtils.SingleIt
 import static io.soabase.recordbuilder.processor.CollectionBuilderUtils.SingleItemsMetaDataMode.STANDARD_FOR_SETTER;
 import static io.soabase.recordbuilder.processor.ElementUtils.*;
 import static io.soabase.recordbuilder.processor.ParameterSpecUtil.createParameterSpec;
-import static io.soabase.recordbuilder.processor.RecordBuilderProcessor.generatedRecordBuilderAnnotation;
-import static io.soabase.recordbuilder.processor.RecordBuilderProcessor.recordBuilderGeneratedAnnotation;
+import static io.soabase.recordbuilder.processor.RecordBuilderProcessor.*;
 import static javax.tools.Diagnostic.Kind.ERROR;
 
 class InternalRecordBuilderProcessor {
@@ -88,6 +87,7 @@ class InternalRecordBuilderProcessor {
         if (metaData.addClassRetainedGenerated()) {
             builder.addAnnotation(recordBuilderGeneratedAnnotation);
         }
+        builder.addAnnotation(suppressWarningsAnnotation);
 
         if (!validateMethodNameConflicts(processingEnv, recordFacade.element())) {
             builderType = Optional.empty();
@@ -264,6 +264,7 @@ class InternalRecordBuilderProcessor {
         if (metaData.addClassRetainedGenerated()) {
             classBuilder.addAnnotation(recordBuilderGeneratedAnnotation);
         }
+        classBuilder.addAnnotation(suppressWarningsAnnotation);
 
         MethodSpec buildMethod = buildMethod().addModifiers(Modifier.PUBLIC, Modifier.DEFAULT)
                 .addStatement("return $L().$L()", metaData.builderMethodName(), metaData.buildMethodName()).build();
@@ -313,6 +314,7 @@ class InternalRecordBuilderProcessor {
         if (metaData.addClassRetainedGenerated()) {
             classBuilder.addAnnotation(recordBuilderGeneratedAnnotation);
         }
+        classBuilder.addAnnotation(suppressWarningsAnnotation);
 
         var returnType = nextComponent.map(this::stagedBuilderType)
                 .orElseGet(() -> stagedBuilderType(builderClassType));
@@ -375,6 +377,7 @@ class InternalRecordBuilderProcessor {
         if (metaData.addClassRetainedGenerated()) {
             classBuilder.addAnnotation(recordBuilderGeneratedAnnotation);
         }
+        classBuilder.addAnnotation(suppressWarningsAnnotation);
         recordComponents.forEach(component -> addNestedGetterMethod(classBuilder, component, component.name()));
         addWithBuilderMethod(classBuilder);
         addWithSuppliedBuilderMethod(classBuilder);
@@ -398,7 +401,7 @@ class InternalRecordBuilderProcessor {
         var classBuilder = TypeSpec.interfaceBuilder(metaData.beanClassName())
                 .addAnnotation(generatedRecordBuilderAnnotation)
                 .addJavadoc("Add getters to {@code $L}\n", recordClassType.name()).addModifiers(Modifier.PUBLIC)
-                .addTypeVariables(typeVariables);
+                .addTypeVariables(typeVariables).addAnnotation(suppressWarningsAnnotation);
         recordComponents.forEach(component -> {
             if (prefixedName(component, true).equals(component.name())) {
                 return;
@@ -754,6 +757,7 @@ class InternalRecordBuilderProcessor {
         if (metaData.addClassRetainedGenerated()) {
             fromWithClassBuilder.addAnnotation(recordBuilderGeneratedAnnotation);
         }
+        fromWithClassBuilder.addAnnotation(suppressWarningsAnnotation);
 
         fromWithClassBuilder.addField(recordClassType.typeName(), "from", Modifier.PRIVATE, Modifier.FINAL);
         MethodSpec constructorSpec = MethodSpec.constructorBuilder().addParameter(recordClassType.typeName(), "from")
@@ -1216,7 +1220,8 @@ class InternalRecordBuilderProcessor {
         }
         return TypeSpec.interfaceBuilder(className).addAnnotation(generatedRecordBuilderAnnotation)
                 .addAnnotation(FunctionalInterface.class).addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-                .addTypeVariables(localTypeVariables).addMethod(methodBuilder.build()).build();
+                .addTypeVariables(localTypeVariables).addMethod(methodBuilder.build())
+                .addAnnotation(suppressWarningsAnnotation).build();
     }
 
     private String prefixedName(RecordClassType component, boolean isGetter) {

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/InternalRecordInterfaceProcessor.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/InternalRecordInterfaceProcessor.java
@@ -30,8 +30,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static io.soabase.recordbuilder.processor.ElementUtils.generateName;
-import static io.soabase.recordbuilder.processor.RecordBuilderProcessor.generatedRecordInterfaceAnnotation;
-import static io.soabase.recordbuilder.processor.RecordBuilderProcessor.recordBuilderGeneratedAnnotation;
+import static io.soabase.recordbuilder.processor.RecordBuilderProcessor.*;
 
 class InternalRecordInterfaceProcessor {
     private final ProcessingEnvironment processingEnv;
@@ -94,6 +93,8 @@ class InternalRecordInterfaceProcessor {
                 }
             }
         }
+
+        builder.addAnnotation(suppressWarningsAnnotation);
 
         addAlternateMethods(builder, recordComponents);
 

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/RecordBuilderProcessor.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/RecordBuilderProcessor.java
@@ -47,7 +47,7 @@ public class RecordBuilderProcessor extends AbstractProcessor {
     static final AnnotationSpec generatedRecordBuilderAnnotation = AnnotationSpec.builder(Generated.class)
             .addMember("value", "$S", RecordBuilder.class.getName()).build();
     static final AnnotationSpec suppressWarningsAnnotation = AnnotationSpec.builder(SuppressWarnings.class)
-            .addMember("value", "$S", "unchecked").build();
+            .addMember("value", "{$S, $S}", "all", "cast").build();
     static final AnnotationSpec generatedRecordInterfaceAnnotation = AnnotationSpec.builder(Generated.class)
             .addMember("value", "$S", RecordInterface.class.getName()).build();
     static final AnnotationSpec recordBuilderGeneratedAnnotation = AnnotationSpec.builder(RecordBuilderGenerated.class)

--- a/record-builder-test/src/main/java/io/soabase/recordbuilder/test/DeprecatedComponentRecord.java
+++ b/record-builder-test/src/main/java/io/soabase/recordbuilder/test/DeprecatedComponentRecord.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 The original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.soabase.recordbuilder.test;
+
+import io.soabase.recordbuilder.core.RecordBuilder;
+
+@RecordBuilder
+public record DeprecatedComponentRecord(@Deprecated String oldField, String newField)
+        implements DeprecatedComponentRecordBuilder.With {
+}


### PR DESCRIPTION
When a record component is annotated with `@Deprecated`, the generated builder code references deprecated accessors, causing compilation warnings (or errors with `-Werror`). This adds `@SuppressWarnings({"all", "cast"})` at the class level on all generated classes, interfaces, and records.

Fixes #273.