### PR TITLE
Start claiming the annotations we process + New option `inheritRecordAnnotations`

### DIFF
--- a/options.md
+++ b/options.md
@@ -56,20 +56,20 @@ The names used for generated methods, classes, etc. can be changed via the follo
 
 ## Miscellaneous
 
-| option                                                                     | details                                                                                                                                                          |
-|----------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `@RecordBuilder.Options(inheritComponentAnnotations = true/false)`         | If true, any annotations (if applicable) on record components are copied to the builder methods. The default is `true`.                                          |
-| `@RecordBuilder.Options(publicBuilderConstructors = true/false)`           | Makes the generated builder's constructors public. The default is `false`.                                                                                       |
-| `@RecordBuilder.Options(builderClassModifiers = {}})`                      | Any additional `javax.lang.model.element.Modifier` you wish to apply to the builder.                                                                             |
-| `@RecordBuilder.Options(beanClassName = "Foo")`                            | If set, the Builder will contain an internal interface with this name.                                                                                           |
-| `@RecordBuilder.Options(addClassRetainedGenerated = true/false)`           | If true, generated classes are annotated with `RecordBuilderGenerated`. The default is `false`.                                                                  |
-| `@RecordBuilder.Options(addStaticBuilder = true/false)`                    | If true, a functional-style builder is added so that record instances can be instantiated without `new()`. The default is `true`.                                |
-| `@RecordBuilder.Options(inheritComponentAnnotations = true/false)`         | If true, any annotations (if applicable) on record components are copied to the builder methods. The default is `true`.                                          |
-| `@RecordBuilder.Options(addConcreteSettersForOptional = <mode>)`           | Add non-optional setter methods for optional record components. The default is `ConcreteSettersForOptionalMode.DISABLED`.                                        |
-| `@RecordBuilder.Options(nullableAnnotationClass = "com.foo.Nullable")`     | Nullability annotation to use when RecordBuilder needs to add one.                                                                                               |
-| `@RecordBuilder.Options(useValidationApi = true/false)`                    | Pass built records through the Java Validation API if it's available in the classpath. The default is `false`.                                                   |
-| `@RecordBuilder.Options(builderMode = BuilderMode.XXX)`                    | Whether to add standard builder, staged builder or both. The default is `BuilderMode.STANDARD`.                                                                  |
-| `@RecordBuilder.Options(onceOnlyAssignment = true/false)`                  | If true, attributes can be set/assigned only 1 time. Attempts to reassign/reset attributes will throw `java.lang.IllegalStateException`. The default is `false`. |
+| option                                                                 | details                                                                                                                                                          |
+|------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `@RecordBuilder.Options(inheritComponentAnnotations = true/false)`     | If true, any annotations (if applicable) on record components are copied to the builder methods. The default is `true`.                                          |
+| `@RecordBuilder.Options(publicBuilderConstructors = true/false)`       | Makes the generated builder's constructors public. The default is `false`.                                                                                       |
+| `@RecordBuilder.Options(builderClassModifiers = {}})`                  | Any additional `javax.lang.model.element.Modifier` you wish to apply to the builder.                                                                             |
+| `@RecordBuilder.Options(beanClassName = "Foo")`                        | If set, the Builder will contain an internal interface with this name.                                                                                           |
+| `@RecordBuilder.Options(addClassRetainedGenerated = true/false)`       | If true, generated classes are annotated with `RecordBuilderGenerated`. The default is `false`.                                                                  |
+| `@RecordBuilder.Options(addStaticBuilder = true/false)`                | If true, a functional-style builder is added so that record instances can be instantiated without `new()`. The default is `true`.                                |
+| `@RecordBuilder.Options(addConcreteSettersForOptional = <mode>)`       | Add non-optional setter methods for optional record components. The default is `ConcreteSettersForOptionalMode.DISABLED`.                                        |
+| `@RecordBuilder.Options(nullableAnnotationClass = "com.foo.Nullable")` | Nullability annotation to use when RecordBuilder needs to add one.                                                                                               |
+| `@RecordBuilder.Options(useValidationApi = true/false)`                | Pass built records through the Java Validation API if it's available in the classpath. The default is `false`.                                                   |
+| `@RecordBuilder.Options(builderMode = BuilderMode.XXX)`                | Whether to add standard builder, staged builder or both. The default is `BuilderMode.STANDARD`.                                                                  |
+| `@RecordBuilder.Options(onceOnlyAssignment = true/false)`              | If true, attributes can be set/assigned only 1 time. Attempts to reassign/reset attributes will throw `java.lang.IllegalStateException`. The default is `false`. |
+| `@RecordBuilder.Options(inheritRecordAnnotations = {})`                | Set of annotations that are copied from the record to the generated builder when `inheritComponentAnnotations()` is `true`.                                       |
 
 ### Staged Builders
 

--- a/record-builder-core/src/main/java/io/soabase/recordbuilder/core/RecordBuilder.java
+++ b/record-builder-core/src/main/java/io/soabase/recordbuilder/core/RecordBuilder.java
@@ -359,6 +359,14 @@ public @interface RecordBuilder {
          * @see #nullablePattern
          */
         boolean defaultNotNull() default false;
+
+        /**
+         * Set of annotations that are copied from the record to the generated builder if
+         * {@link #inheritComponentAnnotations()} is true
+         *
+         * @return annotations
+         */
+        String[] inheritRecordAnnotations() default { "java.lang.SuppressWarnings" };
     }
 
     @Retention(RetentionPolicy.CLASS)

--- a/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/InternalRecordBuilderProcessor.java
+++ b/record-builder-processor/src/main/java/io/soabase/recordbuilder/processor/InternalRecordBuilderProcessor.java
@@ -23,6 +23,7 @@ import io.soabase.recordbuilder.processor.CollectionBuilderUtils.SingleItemsMeta
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeElement;
 import java.lang.annotation.ElementType;
 import java.util.*;
 import java.util.function.BiConsumer;
@@ -93,6 +94,8 @@ class InternalRecordBuilderProcessor {
             builderType = Optional.empty();
             return;
         }
+
+        addInheritedRecordAnnotations(builder, recordFacade, metaData);
 
         addVisibility(recordFacade.builderIsInRecordPackage(), recordFacade.modifiers());
         if (metaData.enableWither()) {
@@ -184,6 +187,17 @@ class InternalRecordBuilderProcessor {
 
             return true;
         });
+    }
+
+    private void addInheritedRecordAnnotations(TypeSpec.Builder builder, RecordFacade recordFacade,
+            RecordBuilder.Options metaData) {
+        if (metaData.inheritComponentAnnotations()) {
+            Set<String> inheritRecordAnnotationsInclusions = Set.of(metaData.inheritRecordAnnotations());
+            recordFacade.element().getAnnotationMirrors().stream()
+                    .filter(annotation -> inheritRecordAnnotationsInclusions.contains(
+                            ((TypeElement) annotation.getAnnotationType().asElement()).getQualifiedName().toString()))
+                    .map(AnnotationSpec::get).forEach(builder::addAnnotation);
+        }
     }
 
     private void addVisibility(boolean builderIsInRecordPackage, Set<Modifier> modifiers) {


### PR DESCRIPTION
Augments `inheritComponentAnnotations` by supplying a list of record-level
annotations that should be copied. Nominally this is for `SuppressWarnings`
but it can be used for any set of annotations.

Fixes https://github.com/Randgalt/record-builder/issues/273